### PR TITLE
Add foundation pre-commit workflow

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+set -eu
+
+npm test
+npm run validate:foundation
+npm run decompose:dry-run

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-25T04:07:23.360Z for PR creation at branch issue-5-c1168a255ffa for issue https://github.com/xlabtg/Teleton-Client/issues/5

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-25T04:07:23.360Z for PR creation at branch issue-5-c1168a255ffa for issue https://github.com/xlabtg/Teleton-Client/issues/5

--- a/BUILD-GUIDE.md
+++ b/BUILD-GUIDE.md
@@ -20,6 +20,16 @@ npm run decompose:dry-run
 
 No dependency installation is required for the current foundation package because it uses only Node.js built-ins.
 
+## Pre-commit Checks
+
+Enable the repository hook path once per clone:
+
+```sh
+npm run prepare:hooks
+```
+
+The pre-commit hook runs the same foundation checks as CI before allowing a commit.
+
 ## Epic Decomposition
 
 Preview the planned subissues without changing GitHub:

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ npm run validate:foundation
 npm run decompose:dry-run
 ```
 
+Enable local pre-commit checks with:
+
+```sh
+npm run prepare:hooks
+```
+
 ## Architecture Direction
 
 The project is intended to evolve through these layers:

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "description": "Universal AI messenger foundation based on Telegram, Teleton Agent, and TON.",
   "scripts": {
     "test": "node --test test/*.test.mjs",
+    "prepare:hooks": "git config core.hooksPath .githooks",
     "validate:foundation": "node scripts/validate-foundation.mjs",
     "decompose:dry-run": "node scripts/decompose-epic.mjs --dry-run"
   },

--- a/scripts/validate-foundation.mjs
+++ b/scripts/validate-foundation.mjs
@@ -10,6 +10,7 @@ const requiredFiles = [
   'PRIVACY.md',
   'BUILD-GUIDE.md',
   'LICENSE',
+  '.githooks/pre-commit',
   '.github/workflows/ci.yml',
   '.github/ISSUE_TEMPLATE/subtask.yml',
   'config/epic-subtasks.json',

--- a/test/foundation.test.mjs
+++ b/test/foundation.test.mjs
@@ -19,6 +19,7 @@ test('foundation artifacts required by issue 1 are present', () => {
     'PRIVACY.md',
     'BUILD-GUIDE.md',
     'LICENSE',
+    '.githooks/pre-commit',
     '.github/workflows/ci.yml',
     '.github/ISSUE_TEMPLATE/subtask.yml',
     'config/epic-subtasks.json'


### PR DESCRIPTION
## Summary

Adds a local pre-commit workflow for the repository foundation task and documents how contributors enable it.

## Changes

- Adds `.githooks/pre-commit` to run the same foundation checks used by CI.
- Adds `npm run prepare:hooks` to configure `core.hooksPath` for a clone.
- Updates README and build guide instructions.
- Extends foundation validation and tests so the pre-commit hook remains a required artifact.

## Verification

- `npm test`
- `npm run validate:foundation`
- `npm run decompose:dry-run`

Fixes #5