### PR TITLE
Complete EPIC #1 subtask expansion

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-25T04:28:04.022Z for PR creation at branch issue-31-4afcda2853b4 for issue https://github.com/xlabtg/Teleton-Client/issues/31


### PR DESCRIPTION
## Summary

- Created the 38 missing canonical EPIC #1 subtask issues for task IDs `#004`-`#009`, `#013`-`#019`, `#024`-`#029`, `#034`-`#039`, `#044`-`#049`, and `#053`-`#059`.
- Expanded `config/epic-subtasks.json` to the full ordered `#001`-`#063` task set, with published `issueNumber` and `issueUrl` links for every subtask.
- Tightened foundation validation and tests so regressions fail unless the manifest contains exactly 63 contiguous task IDs.
- Updated backlog documentation to reflect the original published issues `#5`-`#29` plus follow-up expansion issues `#33`-`#70`.

## Scope Note

Issue #31 also lists `#064`-`#070` under one section, but its stated goal is a complete `#001`-`#063` set and its missing-task count is 38. This PR follows that canonical 63-task target; the existing `#060`-`#063` entries remain the Testing and Release tasks for EPIC #1.

## Testing

- `npm test`
- `npm run validate:foundation`
- `npm run decompose:dry-run`

Fixes #31
