### PR TITLE
[002] Integrate TDLib build plan and baseline client adapter

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-25T04:28:04.022Z for PR creation at branch issue-31-4afcda2853b4 for issue https://github.com/xlabtg/Teleton-Client/issues/31

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-25T04:28:04.022Z for PR creation at branch issue-31-4afcda2853b4 for issue https://github.com/xlabtg/Teleton-Client/issues/31
+# Updated: 2026-04-25T04:45:09.677Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-25T04:28:04.022Z for PR creation at branch issue-31-4afcda2853b4 for issue https://github.com/xlabtg/Teleton-Client/issues/31
-# Updated: 2026-04-25T04:45:09.677Z

--- a/BUILD-GUIDE.md
+++ b/BUILD-GUIDE.md
@@ -8,6 +8,19 @@ Teleton Client is currently in the repository foundation phase. The present code
 - GitHub CLI (`gh`) for creating GitHub issues from the epic backlog.
 - A GitHub account with write access to `xlabtg/Teleton-Client` when running issue creation.
 
+## TDLib Build Targets
+
+The current repository does not compile TDLib yet. The baseline adapter boundary in `src/tdlib/client-adapter.mjs` defines the platform-neutral contract that future native builds must implement for Android, iOS, desktop, and web-compatible callers.
+
+Future TDLib build work should produce:
+
+- Android native artifacts for supported NDK ABIs.
+- iOS device and simulator artifacts packaged for the app wrapper.
+- desktop artifacts for Linux, macOS, and Windows through a native module or helper process.
+- a web-compatible bridge that calls a trusted local service or backend instead of shipping raw TDLib credentials into a browser runtime.
+
+TDLib is distributed under the Boost Software License 1.0 (`BSL-1.0`). Future build scripts must preserve upstream license notices, record the TDLib source revision, and document local patches or packaging changes. See `docs/tdlib-adapter.md` for the adapter boundary and credential-handling rules.
+
 ## Local Checks
 
 Run the same checks used by CI:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository is in the foundation phase. The current implementation establish
 - Published GitHub subissues for the issue `#1` decomposition, tracked in the manifest.
 - Dry-run and idempotent GitHub issue creation script for decomposing issue `#1`.
 - Shared agent mode and proxy settings models with tests.
+- Baseline TDLib client adapter contract with mock-backed tests.
 - CI workflow for foundation checks.
 - Required project documents: `README.md`, `PRIVACY.md`, `LICENSE`, and `BUILD-GUIDE.md`.
 
@@ -38,7 +39,7 @@ The project is intended to evolve through these layers:
 4. TON blockchain integrations for wallet, transfers, swaps, NFTs, staking, and DNS.
 5. Security and privacy controls for credentials, user consent, and auditability.
 
-See `docs/architecture.md` and `docs/backlog.md` for the current foundation plan.
+See `docs/architecture.md`, `docs/backlog.md`, and `docs/tdlib-adapter.md` for the current foundation plan.
 
 ## Issue Decomposition
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,10 +15,11 @@ Teleton Client is planned as a layered client where protocol, automation, wallet
 ## Boundaries
 
 - TDLib credentials must be supplied at runtime and never committed.
+- TDLib callers use the shared `authenticate`, `getChatList`, `sendMessage`, and `subscribeUpdates` adapter contract so Android, iOS, desktop, and web-compatible bridges expose the same boundary.
 - Agent mode defaults to `off`; cloud and hybrid modes require explicit activation.
 - Proxy secrets are represented as secure references such as `env:NAME`, `keychain:name`, or `keystore:name`.
 - TON signing requires user confirmation and platform secure storage or wallet-provider approval.
 
 ## Foundation Status
 
-This PR implements only the foundation layer and epic decomposition workflow. Platform UI shells, live TDLib integration, live agent runtime, and live TON operations remain tracked by the generated subtasks in `config/epic-subtasks.json`.
+This PR implements only the foundation layer, epic decomposition workflow, and baseline TDLib adapter boundary. Platform UI shells, live TDLib integration, live agent runtime, and live TON operations remain tracked by the generated subtasks in `config/epic-subtasks.json`.

--- a/docs/tdlib-adapter.md
+++ b/docs/tdlib-adapter.md
@@ -1,0 +1,48 @@
+# TDLib Adapter Boundary
+
+The shared TDLib adapter is the first boundary between platform callers and a future native TDLib bridge. It does not link TDLib yet, does not connect to Telegram, and does not require live Telegram credentials for tests.
+
+## Supported Callers
+
+- Android callers use the same adapter contract over a JVM or native bridge that owns TDLib lifecycle and secure storage lookup.
+- iOS callers use the same adapter contract over a Swift or Objective-C bridge that owns TDLib lifecycle and keychain lookup.
+- desktop callers use the same adapter contract over a local native module, helper process, or IPC bridge for Linux, macOS, and Windows.
+- web-compatible callers use the same adapter contract over a local companion service or trusted backend bridge. Raw TDLib binaries and Telegram credentials must not be shipped into an untrusted browser runtime.
+
+## Contract
+
+The adapter exposes four operations:
+
+- `authenticate(request)` validates Telegram credential references before the platform bridge begins TDLib authorization.
+- `getChatList(query)` returns a bounded page of chats with an adapter-owned cursor.
+- `sendMessage(draft)` validates chat and text inputs before the platform bridge sends a message.
+- `subscribeUpdates(listener, options)` registers a typed update listener and returns an unsubscribe function.
+
+Authentication accepts secure references only:
+
+```js
+{
+  apiIdRef: 'env:TELEGRAM_API_ID',
+  apiHashRef: 'keychain:telegram-api-hash',
+  phoneNumberRef: 'keystore:telegram-phone'
+}
+```
+
+The shared adapter rejects raw `apiId`, `api_id`, `apiHash`, `api_hash`, `phoneNumber`, and `botToken` values. Platform bridges are responsible for resolving references through environment variables, keychains, keystores, secret managers, or equivalent local secure storage.
+
+## Mock Testing
+
+`createMockTdlibClientAdapter` implements the same public contract without TDLib, Telegram network access, phone numbers, bot tokens, or live user credentials. Tests can seed chat fixtures, send mock messages, and subscribe to mock updates while preserving the same validation path used by native bridge adapters.
+
+## Build Targets
+
+TDLib integration work should produce native artifacts for these targets before platform wrappers consume them:
+
+- Android: NDK and CMake builds for the supported Android ABIs, packaged through the Android app wrapper.
+- iOS: CMake or Xcode builds for device and simulator architectures, packaged as a framework or library consumed by the iOS app wrapper.
+- desktop: CMake builds for Linux, macOS, and Windows, exposed through a native module or helper process.
+- web-compatible: no direct browser TDLib binary in the foundation layer. Use a local companion service or backend bridge that implements this adapter contract.
+
+## Licensing
+
+TDLib is distributed under the Boost Software License 1.0 (`BSL-1.0`). Future build scripts and packaged artifacts must preserve upstream license notices, record the TDLib source revision used for reproducible builds, and document any local patches. The repository MIT license does not replace TDLib's upstream license obligations.

--- a/scripts/validate-foundation.mjs
+++ b/scripts/validate-foundation.mjs
@@ -15,7 +15,8 @@ const requiredFiles = [
   '.github/ISSUE_TEMPLATE/subtask.yml',
   'config/epic-subtasks.json',
   'docs/architecture.md',
-  'docs/backlog.md'
+  'docs/backlog.md',
+  'docs/tdlib-adapter.md'
 ];
 
 for (const requiredFile of requiredFiles) {
@@ -67,7 +68,7 @@ for (const subtask of manifest.subtasks) {
   assert.ok(Array.isArray(subtask.acceptanceCriteria) && subtask.acceptanceCriteria.length >= 2);
 }
 
-const docsToScan = ['README.md', 'PRIVACY.md', 'BUILD-GUIDE.md', 'docs/architecture.md'];
+const docsToScan = ['README.md', 'PRIVACY.md', 'BUILD-GUIDE.md', 'docs/architecture.md', 'docs/tdlib-adapter.md'];
 const forbiddenPatterns = [
   /api_hash\s*[:=]\s*['"][^'"]+['"]/i,
   /api_id\s*[:=]\s*\d{4,}/i,

--- a/src/tdlib/client-adapter.mjs
+++ b/src/tdlib/client-adapter.mjs
@@ -1,0 +1,308 @@
+import { isSecureReference } from '../foundation/proxy-settings.mjs';
+
+export const TDLIB_PLATFORMS = Object.freeze(['android', 'ios', 'desktop', 'web']);
+export const TDLIB_UPDATE_TYPES = Object.freeze(['authorizationState', 'connectionState', 'chatList', 'message']);
+
+const REQUIRED_IMPLEMENTATION_METHODS = ['authenticate', 'getChatList', 'sendMessage', 'subscribeUpdates'];
+const MAX_CHAT_LIST_LIMIT = 100;
+const MAX_MESSAGE_TEXT_LENGTH = 4096;
+
+export class TdlibAdapterError extends Error {
+  constructor(message, code, details = []) {
+    super(message);
+    this.name = 'TdlibAdapterError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function adapterError(errors, code) {
+  return new TdlibAdapterError(errors.join(' '), code, errors);
+}
+
+function normalizePlatform(value) {
+  const platform = String(value ?? '').trim().toLowerCase();
+
+  if (!TDLIB_PLATFORMS.includes(platform)) {
+    throw new TdlibAdapterError(`Unsupported TDLib platform: ${value}`, 'unsupported_platform');
+  }
+
+  return platform;
+}
+
+function assertBridgeImplementation(implementation) {
+  if (!implementation || typeof implementation !== 'object') {
+    throw new TdlibAdapterError('TDLib adapter implementation must be an object.', 'invalid_implementation');
+  }
+
+  const missingMethods = REQUIRED_IMPLEMENTATION_METHODS.filter((method) => typeof implementation[method] !== 'function');
+  if (missingMethods.length > 0) {
+    throw new TdlibAdapterError(
+      `TDLib adapter implementation is missing methods: ${missingMethods.join(', ')}.`,
+      'invalid_implementation',
+      missingMethods
+    );
+  }
+}
+
+function requireSecureReference(input, sourceField, targetField, errors, request) {
+  if (isSecureReference(input[targetField])) {
+    request[targetField] = input[targetField];
+    return;
+  }
+
+  const rawValueProvided = input[sourceField] !== undefined || input[targetField] !== undefined;
+  const suffix = rawValueProvided ? ' Raw values are not accepted by the shared adapter boundary.' : '';
+  errors.push(`${targetField} must be a secure reference such as env:NAME, keychain:name, or keystore:name.${suffix}`);
+}
+
+export function validateTdlibAuthenticationRequest(input = {}) {
+  const errors = [];
+  const request = {};
+
+  requireSecureReference(input, 'apiId', 'apiIdRef', errors, request);
+  if (input.api_id !== undefined) {
+    errors.push('apiIdRef must be used instead of raw api_id values.');
+  }
+
+  requireSecureReference(input, 'apiHash', 'apiHashRef', errors, request);
+  if (input.api_hash !== undefined) {
+    errors.push('apiHashRef must be used instead of raw api_hash values.');
+  }
+
+  if (input.phoneNumber !== undefined || input.phoneNumberRef !== undefined) {
+    requireSecureReference(input, 'phoneNumber', 'phoneNumberRef', errors, request);
+  }
+
+  if (input.botToken !== undefined || input.botTokenRef !== undefined) {
+    requireSecureReference(input, 'botToken', 'botTokenRef', errors, request);
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    request
+  };
+}
+
+export function validateTdlibChatListQuery(input = {}) {
+  const errors = [];
+  const limit = input.limit === undefined ? 50 : input.limit;
+  const cursor = input.cursor ?? null;
+
+  if (!Number.isInteger(limit) || limit < 1 || limit > MAX_CHAT_LIST_LIMIT) {
+    errors.push(`Chat list limit must be an integer between 1 and ${MAX_CHAT_LIST_LIMIT}.`);
+  }
+
+  if (cursor !== null && (typeof cursor !== 'object' || Array.isArray(cursor))) {
+    errors.push('Chat list cursor must be null or an adapter-provided cursor object.');
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    query: {
+      limit,
+      cursor
+    }
+  };
+}
+
+export function validateTdlibMessageDraft(input = {}) {
+  const errors = [];
+  const chatId = input.chatId === undefined || input.chatId === null ? '' : String(input.chatId).trim();
+  const text = typeof input.text === 'string' ? input.text : '';
+
+  if (!chatId) {
+    errors.push('Message chatId is required.');
+  }
+
+  if (text.trim().length === 0) {
+    errors.push('Message text is required.');
+  }
+
+  if (text.length > MAX_MESSAGE_TEXT_LENGTH) {
+    errors.push(`Message text must be ${MAX_MESSAGE_TEXT_LENGTH} characters or fewer.`);
+  }
+
+  const draft = {
+    chatId,
+    text
+  };
+
+  if (input.replyToMessageId !== undefined) {
+    draft.replyToMessageId = String(input.replyToMessageId);
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    draft
+  };
+}
+
+function validateUpdateSubscription(listener, input = {}) {
+  const errors = [];
+
+  if (typeof listener !== 'function') {
+    errors.push('TDLib update listener must be a function.');
+  }
+
+  let types = null;
+  if (input.types !== undefined) {
+    if (!Array.isArray(input.types)) {
+      errors.push('TDLib update subscription types must be an array.');
+    } else {
+      types = [...new Set(input.types.map((type) => String(type)))];
+      for (const type of types) {
+        if (!TDLIB_UPDATE_TYPES.includes(type)) {
+          errors.push(`Unsupported TDLib update type: ${type}.`);
+        }
+      }
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    subscription: {
+      types
+    }
+  };
+}
+
+export function createTdlibClientAdapter(implementation, options = {}) {
+  assertBridgeImplementation(implementation);
+
+  const platform = normalizePlatform(options.platform ?? implementation.platform ?? 'desktop');
+
+  return Object.freeze({
+    platform,
+    async authenticate(input = {}) {
+      const validation = validateTdlibAuthenticationRequest(input);
+      if (!validation.valid) {
+        throw adapterError(validation.errors, 'invalid_authentication_request');
+      }
+
+      return implementation.authenticate(validation.request);
+    },
+    async getChatList(input = {}) {
+      const validation = validateTdlibChatListQuery(input);
+      if (!validation.valid) {
+        throw adapterError(validation.errors, 'invalid_chat_list_query');
+      }
+
+      return implementation.getChatList(validation.query);
+    },
+    async sendMessage(input = {}) {
+      const validation = validateTdlibMessageDraft(input);
+      if (!validation.valid) {
+        throw adapterError(validation.errors, 'invalid_message_draft');
+      }
+
+      return implementation.sendMessage(validation.draft);
+    },
+    subscribeUpdates(listener, input = {}) {
+      const validation = validateUpdateSubscription(listener, input);
+      if (!validation.valid) {
+        throw adapterError(validation.errors, 'invalid_update_subscription');
+      }
+
+      const unsubscribe = implementation.subscribeUpdates(listener, validation.subscription);
+      if (typeof unsubscribe !== 'function') {
+        throw new TdlibAdapterError('TDLib update subscriptions must return an unsubscribe function.', 'invalid_unsubscribe');
+      }
+
+      return unsubscribe;
+    }
+  });
+}
+
+function cloneCommand(command) {
+  return structuredClone(command);
+}
+
+function cloneChat(chat) {
+  return structuredClone(chat);
+}
+
+function shouldDeliverUpdate(subscription, update) {
+  return subscription.types === null || subscription.types.includes(update.type);
+}
+
+export function createMockTdlibClientAdapter(seed = {}) {
+  const platform = normalizePlatform(seed.platform ?? 'desktop');
+  const chats = Array.isArray(seed.chats) ? seed.chats.map(cloneChat) : [];
+  const commands = [];
+  const subscribers = new Set();
+  let nextMessageId = 1;
+
+  function publish(update) {
+    for (const subscription of subscribers) {
+      if (shouldDeliverUpdate(subscription, update)) {
+        subscription.listener(update);
+      }
+    }
+  }
+
+  const implementation = {
+    platform,
+    async authenticate(request) {
+      commands.push({ method: 'authenticate', request: structuredClone(request) });
+      const session = {
+        authorizationState: 'ready',
+        userId: seed.userId ?? 'mock-user'
+      };
+      publish({ type: 'authorizationState', authorizationState: session.authorizationState, session });
+      return session;
+    },
+    async getChatList(query) {
+      commands.push({ method: 'getChatList', query: structuredClone(query) });
+      const offset = Number.isInteger(query.cursor?.offset) ? query.cursor.offset : 0;
+      const selectedChats = chats.slice(offset, offset + query.limit).map(cloneChat);
+      const nextOffset = offset + selectedChats.length;
+
+      return {
+        chats: selectedChats,
+        nextCursor: nextOffset < chats.length ? { offset: nextOffset } : null
+      };
+    },
+    async sendMessage(draft) {
+      commands.push({ method: 'sendMessage', draft: structuredClone(draft) });
+      const message = {
+        id: `mock-message-${nextMessageId}`,
+        chatId: draft.chatId,
+        text: draft.text,
+        status: 'sent'
+      };
+      nextMessageId += 1;
+
+      publish({ type: 'message', message });
+      return message;
+    },
+    subscribeUpdates(listener, subscription) {
+      commands.push({ method: 'subscribeUpdates', subscription: structuredClone(subscription) });
+      const subscriber = {
+        listener,
+        types: subscription.types
+      };
+      subscribers.add(subscriber);
+
+      return () => {
+        subscribers.delete(subscriber);
+      };
+    }
+  };
+
+  const adapter = createTdlibClientAdapter(implementation, { platform });
+
+  return Object.freeze({
+    ...adapter,
+    emitUpdate(update) {
+      publish(update);
+    },
+    getCommands() {
+      return commands.map(cloneCommand);
+    }
+  });
+}

--- a/test/foundation.test.mjs
+++ b/test/foundation.test.mjs
@@ -22,7 +22,8 @@ test('foundation artifacts required by issue 1 are present', () => {
     '.githooks/pre-commit',
     '.github/workflows/ci.yml',
     '.github/ISSUE_TEMPLATE/subtask.yml',
-    'config/epic-subtasks.json'
+    'config/epic-subtasks.json',
+    'docs/tdlib-adapter.md'
   ];
 
   for (const requiredFile of requiredFiles) {

--- a/test/tdlib-adapter.test.mjs
+++ b/test/tdlib-adapter.test.mjs
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+
+import {
+  TDLIB_PLATFORMS,
+  createMockTdlibClientAdapter,
+  createTdlibClientAdapter,
+  validateTdlibAuthenticationRequest
+} from '../src/tdlib/client-adapter.mjs';
+
+const root = new URL('../', import.meta.url);
+
+function pathFor(relativePath) {
+  return new URL(relativePath, root);
+}
+
+test('TDLib adapter contract declares supported platform callers', () => {
+  assert.deepEqual(TDLIB_PLATFORMS, ['android', 'ios', 'desktop', 'web']);
+
+  const adapter = createMockTdlibClientAdapter({ platform: 'web' });
+
+  assert.equal(adapter.platform, 'web');
+  assert.equal(typeof adapter.authenticate, 'function');
+  assert.equal(typeof adapter.getChatList, 'function');
+  assert.equal(typeof adapter.sendMessage, 'function');
+  assert.equal(typeof adapter.subscribeUpdates, 'function');
+});
+
+test('TDLib authentication rejects raw Telegram credentials and accepts secure references', async () => {
+  const invalid = validateTdlibAuthenticationRequest({
+    apiId: 12345,
+    apiHash: 'not-a-reference',
+    phoneNumber: '+15551234567'
+  });
+
+  assert.equal(invalid.valid, false);
+  assert.match(invalid.errors.join('\n'), /apiIdRef/);
+  assert.match(invalid.errors.join('\n'), /apiHashRef/);
+  assert.match(invalid.errors.join('\n'), /phoneNumberRef/);
+
+  const adapter = createMockTdlibClientAdapter();
+
+  await assert.rejects(
+    () => adapter.authenticate({ apiId: 12345, apiHash: 'not-a-reference' }),
+    /secure reference/
+  );
+
+  const session = await adapter.authenticate({
+    apiIdRef: 'env:TELEGRAM_API_ID',
+    apiHashRef: 'keychain:telegram-api-hash',
+    phoneNumberRef: 'keystore:telegram-phone'
+  });
+
+  assert.equal(session.authorizationState, 'ready');
+  assert.deepEqual(adapter.getCommands().at(-1), {
+    method: 'authenticate',
+    request: {
+      apiIdRef: 'env:TELEGRAM_API_ID',
+      apiHashRef: 'keychain:telegram-api-hash',
+      phoneNumberRef: 'keystore:telegram-phone'
+    }
+  });
+});
+
+test('mock TDLib adapter covers chat list, message send, and update subscription without live credentials', async () => {
+  const adapter = createMockTdlibClientAdapter({
+    chats: [
+      { id: 'chat-1', title: 'General', unreadCount: 2 },
+      { id: 'chat-2', title: 'Support', unreadCount: 0 }
+    ]
+  });
+  const updates = [];
+  const unsubscribe = adapter.subscribeUpdates((update) => updates.push(update), { types: ['message'] });
+
+  const chatList = await adapter.getChatList({ limit: 1 });
+  assert.deepEqual(chatList, {
+    chats: [{ id: 'chat-1', title: 'General', unreadCount: 2 }],
+    nextCursor: { offset: 1 }
+  });
+
+  const sent = await adapter.sendMessage({ chatId: 'chat-1', text: 'Hello from the mock adapter' });
+
+  assert.equal(sent.chatId, 'chat-1');
+  assert.equal(sent.text, 'Hello from the mock adapter');
+  assert.equal(sent.status, 'sent');
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0].type, 'message');
+  assert.equal(updates[0].message.id, sent.id);
+
+  unsubscribe();
+  await adapter.sendMessage({ chatId: 'chat-1', text: 'No subscriber should receive this' });
+  assert.equal(updates.length, 1);
+});
+
+test('TDLib client adapter validates bridge inputs before native calls', async () => {
+  const calls = [];
+  const adapter = createTdlibClientAdapter(
+    {
+      async authenticate(request) {
+        calls.push({ method: 'authenticate', request });
+        return { authorizationState: 'wait_code' };
+      },
+      async getChatList(query) {
+        calls.push({ method: 'getChatList', query });
+        return { chats: [], nextCursor: null };
+      },
+      async sendMessage(draft) {
+        calls.push({ method: 'sendMessage', draft });
+        return { id: 'native-message-1', ...draft, status: 'pending' };
+      },
+      subscribeUpdates(listener) {
+        calls.push({ method: 'subscribeUpdates' });
+        listener({ type: 'connectionState', state: 'ready' });
+        return () => calls.push({ method: 'unsubscribe' });
+      }
+    },
+    { platform: 'android' }
+  );
+
+  assert.equal(adapter.platform, 'android');
+  await assert.rejects(() => adapter.getChatList({ limit: 0 }), /Chat list limit/);
+  await assert.rejects(() => adapter.sendMessage({ chatId: 'chat-1', text: '' }), /Message text/);
+
+  await adapter.getChatList({ limit: 10 });
+  await adapter.sendMessage({ chatId: 'chat-1', text: 'Validated message' });
+  const unsubscribe = adapter.subscribeUpdates(() => {}, { types: ['connectionState'] });
+  unsubscribe();
+
+  assert.deepEqual(calls, [
+    { method: 'getChatList', query: { limit: 10, cursor: null } },
+    { method: 'sendMessage', draft: { chatId: 'chat-1', text: 'Validated message' } },
+    { method: 'subscribeUpdates' },
+    { method: 'unsubscribe' }
+  ]);
+});
+
+test('TDLib build targets, licensing, and adapter boundary are documented', async () => {
+  const buildGuide = await readFile(pathFor('BUILD-GUIDE.md'), 'utf8');
+  const adapterGuide = await readFile(pathFor('docs/tdlib-adapter.md'), 'utf8');
+
+  assert.match(buildGuide, /TDLib Build Targets/);
+  assert.match(adapterGuide, /Android/);
+  assert.match(adapterGuide, /iOS/);
+  assert.match(adapterGuide, /desktop/);
+  assert.match(adapterGuide, /web-compatible/);
+  assert.match(adapterGuide, /Boost Software License/);
+  assert.match(adapterGuide, /apiIdRef/);
+  assert.match(adapterGuide, /apiHashRef/);
+});


### PR DESCRIPTION
## Summary

- Adds a dependency-free TDLib adapter boundary for Android, iOS, desktop, and web-compatible callers.
- Defines validated adapter operations for authentication, chat list paging, message send, and update subscription.
- Rejects raw Telegram `apiId`, `api_id`, `apiHash`, `api_hash`, phone number, and bot token inputs in favor of secure references such as `env:NAME`, `keychain:name`, and `keystore:name`.
- Adds a mock TDLib adapter and contract tests that run without TDLib binaries, Telegram network access, or live user credentials.
- Documents TDLib build targets and Boost Software License 1.0 obligations in `BUILD-GUIDE.md` and `docs/tdlib-adapter.md`.

## Reproduction

Before this work, the repository had no TDLib adapter module or TDLib build boundary documentation. I added `test/tdlib-adapter.test.mjs` first; `npm test` failed with `ERR_MODULE_NOT_FOUND` for `src/tdlib/client-adapter.mjs`, reproducing the missing acceptance surface.

## Verification

- `npm test`
- `npm run validate:foundation`
- `npm run decompose:dry-run`
- `git diff --check`
- GitHub Actions CI passed on commit `ed5a0d5`

Fixes #6
