### PR TITLE
[004] Configure pre-commit hook checks

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-25T05:18:47.759Z for PR creation at branch issue-33-a6ebafb3188a for issue https://github.com/xlabtg/Teleton-Client/issues/33

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-25T05:18:47.759Z for PR creation at branch issue-33-a6ebafb3188a for issue https://github.com/xlabtg/Teleton-Client/issues/33

--- a/test/foundation.test.mjs
+++ b/test/foundation.test.mjs
@@ -31,6 +31,17 @@ test('foundation artifacts required by issue 1 are present', () => {
   }
 });
 
+test('pre-commit hook is installable and runs deterministic local checks', async () => {
+  const hookPath = pathFor('.githooks/pre-commit');
+  assert.equal(existsSync(hookPath), true, 'pre-commit hook should exist');
+
+  const hook = await readFile(hookPath, 'utf8');
+  assert.match(hook, /^#!\/usr\/bin\/env sh\n/, 'pre-commit hook should be directly executable');
+  assert.match(hook, /npm test/, 'pre-commit hook should run the test suite');
+  assert.match(hook, /npm run validate:foundation/, 'pre-commit hook should run foundation validation');
+  assert.match(hook, /npm run decompose:dry-run/, 'pre-commit hook should run the deterministic dry run');
+});
+
 test('epic backlog decomposes issue 1 into prioritized phases', async () => {
   const manifest = await readJson('config/epic-subtasks.json');
 


### PR DESCRIPTION
## Summary
- Adds test coverage for the repository pre-commit hook contract.
- Verifies the hook is executable and runs the same deterministic local checks documented for contributors: `npm test`, `npm run validate:foundation`, and `npm run decompose:dry-run`.
- Removes the generated placeholder `.gitkeep` from the issue branch.

Fixes #33

## Reproduction / Verification
The regression would be a missing or incomplete `.githooks/pre-commit`; `npm test` now fails if the hook entrypoint or expected commands are removed.

## Tests
- `npm test`
- `npm run validate:foundation`
- `npm run decompose:dry-run`
- `.githooks/pre-commit`