### PR TITLE
[005] Add pull request and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,70 @@
+name: Bug report
+description: Report a reproducible Teleton Client defect.
+title: "[Bug] "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for defects with a clear actual result and expected result. Do not include secrets, production credentials, access tokens, Telegram API hashes, private keys, or user-private message content.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the bug and the affected area.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Provide the smallest reliable reproduction.
+      placeholder: |
+        1. Run ...
+        2. Open ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: Describe what should happen.
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Describe what happens instead, including relevant error messages.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Include OS, Node.js version, package manager, app platform, and relevant dependency versions.
+      placeholder: |
+        - OS:
+        - Node.js:
+        - Platform:
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs or screenshots
+      description: Add redacted logs, screenshots, or traces. Remove secrets, credentials, tokens, and private message content before posting.
+    validations:
+      required: false
+  - type: textarea
+    id: tests
+    attributes:
+      label: Tests or checks tried
+      description: List automated or manual checks already run, and whether they passed.
+      placeholder: |
+        - [ ] npm test
+        - [ ] npm run validate:foundation
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_task.yml
+++ b/.github/ISSUE_TEMPLATE/feature_task.yml
@@ -1,0 +1,66 @@
+name: Feature task
+description: Propose bounded product, platform, or infrastructure work.
+title: "[Task] "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for planned Teleton Client work that is not a defect. Do not include secrets, production credentials, access tokens, Telegram API hashes, private keys, or user-private message content.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or goal
+      description: Describe the user, product, or engineering need.
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Describe the bounded implementation work and any explicit non-goals.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List measurable checks that prove the task is complete.
+      placeholder: |
+        - [ ] ...
+        - [ ] ...
+    validations:
+      required: true
+  - type: dropdown
+    id: phase
+    attributes:
+      label: Project area
+      options:
+        - Infrastructure and Core
+        - Connectivity Layer
+        - Teleton Agent Integration
+        - TON Blockchain Module
+        - Platform Wrappers
+        - Security and Licenses
+        - Testing and Release
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: testing
+    attributes:
+      label: Testing plan
+      description: Describe the automated or manual validation expected for this work.
+      placeholder: |
+        - npm test
+        - npm run validate:foundation
+    validations:
+      required: true
+  - type: textarea
+    id: risks
+    attributes:
+      label: Risks and dependencies
+      description: Note compatibility, security, privacy, release, or upstream dependency risks.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/subtask.yml
+++ b/.github/ISSUE_TEMPLATE/subtask.yml
@@ -7,7 +7,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this template for work that belongs to the Teleton Client foundation epic.
+        Use this template for work that belongs to the Teleton Client foundation epic. Do not include secrets, production credentials, access tokens, Telegram API hashes, private keys, or user-private message content.
   - type: input
     id: parent
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Summary
+
+- 
+
+## Issue
+
+Fixes #
+
+## Tests
+
+- [ ] `npm test`
+- [ ] `npm run validate:foundation`
+- [ ] Manual checks, if relevant:
+
+## Risk
+
+- 
+
+## Screenshots or recordings
+
+Add before and after screenshots for UI changes, or write `Not applicable`.
+
+## Security and privacy
+
+- [ ] This PR does not include secrets, production credentials, access tokens, Telegram API hashes, private keys, or private message content.
+- [ ] Any logs, screenshots, or fixtures are redacted.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-25T05:22:01.164Z for PR creation at branch issue-34-c6c473c0b4fb for issue https://github.com/xlabtg/Teleton-Client/issues/34

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-25T05:22:01.164Z for PR creation at branch issue-34-c6c473c0b4fb for issue https://github.com/xlabtg/Teleton-Client/issues/34

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository is in the foundation phase. The current implementation establish
 - Dependency-free Node.js validation and test suite.
 - Machine-readable backlog for the Teleton Client foundation epic.
 - Published GitHub subissues for the issue `#1` decomposition, tracked in the manifest.
+- GitHub issue and pull request templates for reproducible, secret-free contributions.
 - Dry-run and idempotent GitHub issue creation script for decomposing issue `#1`.
 - Shared cross-platform settings model for language, theme, notifications, agent mode, proxy, and secure references.
 - Baseline TDLib client adapter contract with mock-backed tests.
@@ -40,6 +41,10 @@ The project is intended to evolve through these layers:
 5. Security and privacy controls for credentials, user consent, and auditability.
 
 See `docs/architecture.md`, `docs/backlog.md`, and `docs/tdlib-adapter.md` for the current foundation plan.
+
+## Contribution Templates
+
+Use the GitHub issue templates for feature tasks, bug reports, and generated implementation subtasks. Pull requests should use the repository template to link issues, list tests, call out risks, and include screenshots for UI changes. See `docs/contributing-templates.md` for template expectations.
 
 ## Issue Decomposition
 

--- a/docs/contributing-templates.md
+++ b/docs/contributing-templates.md
@@ -1,0 +1,21 @@
+# Contribution Templates
+
+Teleton Client uses GitHub templates to keep issues and pull requests reproducible, reviewable, and safe to discuss publicly.
+
+## Feature Task Issues
+
+Use the feature task template for planned product, platform, infrastructure, documentation, or testing work. Define the goal, bounded scope, acceptance criteria, project area, and testing plan before implementation starts.
+
+## Bug Report Issues
+
+Use the bug report template for defects with observable expected and actual behavior. Include the smallest reliable reproduction, environment details, redacted logs, and the tests or checks already tried.
+
+## Generated Subtasks
+
+Use the implementation subtask template for tasks decomposed from the Teleton Client foundation epic. Keep the parent epic, phase, scope, acceptance criteria, and testing notes aligned with `config/epic-subtasks.json`.
+
+## Pull Requests
+
+Pull requests should summarize the change, link the issue, list tests, call out risks, and include screenshots or recordings for UI work. PR descriptions should stay current as implementation details change.
+
+Never include secrets, production credentials, access tokens, Telegram API hashes, private keys, or private message content in issues, pull requests, logs, screenshots, or fixtures.

--- a/scripts/validate-foundation.mjs
+++ b/scripts/validate-foundation.mjs
@@ -12,8 +12,12 @@ const requiredFiles = [
   'LICENSE',
   '.githooks/pre-commit',
   '.github/workflows/ci.yml',
+  '.github/ISSUE_TEMPLATE/bug_report.yml',
+  '.github/ISSUE_TEMPLATE/feature_task.yml',
   '.github/ISSUE_TEMPLATE/subtask.yml',
+  '.github/pull_request_template.md',
   'config/epic-subtasks.json',
+  'docs/contributing-templates.md',
   'docs/architecture.md',
   'docs/backlog.md',
   'docs/tdlib-adapter.md'

--- a/test/foundation.test.mjs
+++ b/test/foundation.test.mjs
@@ -21,14 +21,45 @@ test('foundation artifacts required by issue 1 are present', () => {
     'LICENSE',
     '.githooks/pre-commit',
     '.github/workflows/ci.yml',
+    '.github/ISSUE_TEMPLATE/bug_report.yml',
+    '.github/ISSUE_TEMPLATE/feature_task.yml',
     '.github/ISSUE_TEMPLATE/subtask.yml',
+    '.github/pull_request_template.md',
     'config/epic-subtasks.json',
+    'docs/contributing-templates.md',
     'docs/tdlib-adapter.md'
   ];
 
   for (const requiredFile of requiredFiles) {
     assert.equal(existsSync(pathFor(requiredFile)), true, `${requiredFile} should exist`);
   }
+});
+
+test('GitHub templates collect reproducible, secret-free contribution details', async () => {
+  const templateFiles = [
+    '.github/ISSUE_TEMPLATE/bug_report.yml',
+    '.github/ISSUE_TEMPLATE/feature_task.yml',
+    '.github/ISSUE_TEMPLATE/subtask.yml',
+    '.github/pull_request_template.md'
+  ];
+
+  for (const templateFile of templateFiles) {
+    const content = await readFile(pathFor(templateFile), 'utf8');
+    assert.match(content, /test|reproduc/i, `${templateFile} should prompt for validation details`);
+    assert.match(content, /secret|credential|token/i, `${templateFile} should warn against secrets`);
+  }
+
+  const bugTemplate = await readFile(pathFor('.github/ISSUE_TEMPLATE/bug_report.yml'), 'utf8');
+  assert.match(bugTemplate, /Expected behavior/i);
+  assert.match(bugTemplate, /Actual behavior/i);
+
+  const featureTemplate = await readFile(pathFor('.github/ISSUE_TEMPLATE/feature_task.yml'), 'utf8');
+  assert.match(featureTemplate, /Acceptance criteria/i);
+
+  const guide = await readFile(pathFor('docs/contributing-templates.md'), 'utf8');
+  assert.match(guide, /feature task/i);
+  assert.match(guide, /bug report/i);
+  assert.match(guide, /pull request/i);
 });
 
 test('epic backlog decomposes issue 1 into prioritized phases', async () => {


### PR DESCRIPTION
## Summary

- Add structured GitHub issue templates for bug reports and feature tasks.
- Add a pull request template that prompts for issue links, tests, risks, screenshots, and secret redaction.
- Document template expectations and extend foundation validation/tests so the templates remain required.

## Issue

Fixes #34

## Tests

- [x] npm test
- [x] npm run validate:foundation

## Risk

- Low. This adds repository metadata and documentation only.

## Screenshots or recordings

Not applicable.

## Security and privacy

- [x] This PR does not include secrets, production credentials, access tokens, Telegram API hashes, private keys, or private message content.
- [x] Templates explicitly warn contributors not to include secrets or private content.