### PR TITLE
Add CODEOWNERS for reviewer assignment

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,32 @@
+# Teleton Client ownership rules.
+#
+# GitHub applies the last matching pattern, so broad defaults stay at the top and
+# higher-risk or more specific areas stay below them.
+
+* @xlabtg/teleton-maintainers
+
+# Documentation and generated planning artifacts.
+docs/ @xlabtg/teleton-maintainers
+README.md @xlabtg/teleton-maintainers
+BUILD-GUIDE.md @xlabtg/teleton-maintainers
+config/ @xlabtg/teleton-maintainers
+
+# Shared foundation code and platform-facing integration boundaries.
+src/ @xlabtg/teleton-maintainers
+src/foundation/ @xlabtg/teleton-maintainers
+src/tdlib/ @xlabtg/teleton-maintainers
+scripts/ @xlabtg/teleton-maintainers
+test/ @xlabtg/teleton-maintainers
+package.json @xlabtg/teleton-maintainers
+
+# Security, privacy, release, and repository automation require human review.
+PRIVACY.md @xlabtg/teleton-maintainers
+LICENSE @xlabtg/teleton-maintainers
+.github/ @xlabtg/teleton-maintainers
+.github/workflows/ @xlabtg/teleton-maintainers
+.github/CODEOWNERS @xlabtg/teleton-maintainers
+
+# Ownership changes
+# Changes to this file, security or privacy documentation, release automation,
+# CI workflows, package metadata, and shared client code must be reviewed by a
+# human maintainer before merge.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-25T05:31:02.632Z for PR creation at branch issue-36-6d9d01a2c72e for issue https://github.com/xlabtg/Teleton-Client/issues/36

--- a/docs/contributing-templates.md
+++ b/docs/contributing-templates.md
@@ -19,3 +19,9 @@ Use the implementation subtask template for tasks decomposed from the Teleton Cl
 Pull requests should summarize the change, link the issue, list tests, call out risks, and include screenshots or recordings for UI work. PR descriptions should stay current as implementation details change.
 
 Never include secrets, production credentials, access tokens, Telegram API hashes, private keys, or private message content in issues, pull requests, logs, screenshots, or fixtures.
+
+## Ownership Rules
+
+Repository ownership is defined in `.github/CODEOWNERS`. Changes to security and privacy documentation, CI and release automation, package metadata, platform integration boundaries, shared client code, and CODEOWNERS itself must be reviewed by a human maintainer before merge.
+
+When ownership needs to change, update `.github/CODEOWNERS` in the same pull request as the related repository-area change and explain why the new owner mapping is appropriate.

--- a/scripts/validate-foundation.mjs
+++ b/scripts/validate-foundation.mjs
@@ -15,6 +15,7 @@ const requiredFiles = [
   '.github/ISSUE_TEMPLATE/bug_report.yml',
   '.github/ISSUE_TEMPLATE/feature_task.yml',
   '.github/ISSUE_TEMPLATE/subtask.yml',
+  '.github/CODEOWNERS',
   '.github/pull_request_template.md',
   'config/epic-subtasks.json',
   'docs/contributing-templates.md',
@@ -26,6 +27,34 @@ const requiredFiles = [
 for (const requiredFile of requiredFiles) {
   assert.equal(existsSync(new URL(requiredFile, root)), true, `${requiredFile} is required`);
 }
+
+const codeowners = await readFile(new URL('.github/CODEOWNERS', root), 'utf8');
+const requiredOwnershipPatterns = [
+  '*',
+  '.github/',
+  '.github/workflows/',
+  '.github/CODEOWNERS',
+  'src/',
+  'src/tdlib/',
+  'src/foundation/',
+  'scripts/',
+  'config/',
+  'docs/',
+  'PRIVACY.md',
+  'BUILD-GUIDE.md',
+  'package.json'
+];
+
+for (const pattern of requiredOwnershipPatterns) {
+  assert.match(
+    codeowners,
+    new RegExp(`^${pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s+@`, 'm'),
+    `${pattern} must have CODEOWNERS coverage`
+  );
+}
+
+assert.match(codeowners, /# Ownership changes/i, 'CODEOWNERS must document ownership review rules');
+assert.match(codeowners, /human maintainer/i, 'CODEOWNERS must require human review for high-risk changes');
 
 const manifest = JSON.parse(await readFile(new URL('config/epic-subtasks.json', root), 'utf8'));
 const requiredPhases = [

--- a/test/foundation.test.mjs
+++ b/test/foundation.test.mjs
@@ -24,6 +24,7 @@ test('foundation artifacts required by issue 1 are present', () => {
     '.github/ISSUE_TEMPLATE/bug_report.yml',
     '.github/ISSUE_TEMPLATE/feature_task.yml',
     '.github/ISSUE_TEMPLATE/subtask.yml',
+    '.github/CODEOWNERS',
     '.github/pull_request_template.md',
     'config/epic-subtasks.json',
     'docs/contributing-templates.md',
@@ -33,6 +34,33 @@ test('foundation artifacts required by issue 1 are present', () => {
   for (const requiredFile of requiredFiles) {
     assert.equal(existsSync(pathFor(requiredFile)), true, `${requiredFile} should exist`);
   }
+});
+
+test('CODEOWNERS routes high-risk repository areas to human maintainers', async () => {
+  const codeowners = await readFile(pathFor('.github/CODEOWNERS'), 'utf8');
+
+  const requiredPatterns = [
+    '*',
+    '.github/',
+    '.github/workflows/',
+    '.github/CODEOWNERS',
+    'src/',
+    'src/tdlib/',
+    'src/foundation/',
+    'scripts/',
+    'config/',
+    'docs/',
+    'PRIVACY.md',
+    'BUILD-GUIDE.md',
+    'package.json'
+  ];
+
+  for (const pattern of requiredPatterns) {
+    assert.match(codeowners, new RegExp(`^${pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s+@`, 'm'), `${pattern} should have an owner`);
+  }
+
+  assert.match(codeowners, /# Ownership changes/i, 'CODEOWNERS should document ownership review rules');
+  assert.match(codeowners, /human maintainer/i, 'CODEOWNERS should require human review for ownership changes');
 });
 
 test('GitHub templates collect reproducible, secret-free contribution details', async () => {


### PR DESCRIPTION
## Summary
- Add .github/CODEOWNERS coverage for default, docs, CI, security/privacy, package metadata, shared source, scripts, and tests.
- Document ownership-change review expectations for future maintainers.
- Extend foundation tests and validation so CODEOWNERS coverage remains enforced in CI.

Fixes #36

## Tests
- npm test
- npm run validate:foundation
- npm run decompose:dry-run

## Notes
- CODEOWNERS routes high-risk repository areas to @xlabtg/teleton-maintainers for human review.