### PR TITLE
Add CONTRIBUTING.md contributor guidelines

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-25T05:31:02.632Z for PR creation at branch issue-36-6d9d01a2c72e for issue https://github.com/xlabtg/Teleton-Client/issues/36
+# Updated: 2026-04-25T05:35:31.325Z

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,80 @@
+# Contributing
+
+Teleton Client is in the repository foundation phase. Contributions should keep the project easy to validate, safe to review publicly, and aligned with the documented architecture.
+
+## Local Setup
+
+Use Node.js 20 or newer. The current foundation package uses only Node.js built-ins, so no dependency installation is required before running the checks.
+
+Start with:
+
+```sh
+npm test
+npm run validate:foundation
+npm run validate:release
+npm run decompose:dry-run
+```
+
+Enable the repository pre-commit hook once per clone:
+
+```sh
+npm run prepare:hooks
+```
+
+See `BUILD-GUIDE.md` for build requirements, validation commands, release metadata expectations, and the epic decomposition workflow.
+
+## Choosing Work
+
+Use the GitHub issue templates for new feature tasks and bug reports. Generated implementation subtasks should stay aligned with the parent epic, phase, scope, acceptance criteria, and testing notes recorded in `config/epic-subtasks.json`.
+
+Before starting work, read the related issue, linked documentation, and any existing pull request discussion. If the issue is unclear, ask for clarification before implementing.
+
+## Branches, Commits, and Pull Requests
+
+Create a branch for each bounded change. Keep commits focused, reviewable, and useful on their own when possible. Do not mix unrelated refactors, formatting churn, or generated artifact updates into a feature or bug-fix commit unless they are required for the change.
+
+Pull requests should:
+
+- Link the issue they resolve.
+- Summarize the implementation and any non-obvious tradeoffs.
+- List the local validation commands that were run.
+- Call out risks, follow-up work, or manual checks.
+- Include screenshots or recordings for UI changes.
+- Stay current as the implementation changes.
+
+Use `.github/pull_request_template.md` for the required sections. See `docs/contributing-templates.md` for issue and pull request template expectations, including ownership review rules.
+
+## Validation
+
+Run the same checks used by CI before opening a pull request and again before asking for review:
+
+```sh
+npm test
+npm run validate:foundation
+npm run validate:release
+npm run decompose:dry-run
+```
+
+For bug fixes, add the smallest automated test that reproduces the issue before the fix. For documentation-only changes, update or add validation coverage when a stable repository rule can be checked automatically.
+
+## Security and Privacy
+
+Never commit or post secrets, production credentials, access tokens, Telegram API IDs or hashes, MTProto secrets, proxy credentials, TON wallet private keys, private message content, or unredacted logs.
+
+Represent sensitive runtime values through environment variables or secure storage references such as `env:TELETON_MTPROTO_SECRET`, `keychain:teleton-agent-token`, or `keystore:ton-wallet`.
+
+Public issues, pull requests, screenshots, fixtures, and logs must be redacted before sharing. Report vulnerabilities through GitHub private security advisories instead of public issues.
+
+Security, privacy, CI, release automation, package metadata, shared client code, and CODEOWNERS changes require human maintainer review according to `.github/CODEOWNERS`.
+
+## Project Documentation
+
+Use these documents as the source of truth for foundation work:
+
+- `README.md` for the current repository status and quick start.
+- `BUILD-GUIDE.md` for local checks, release metadata, and build expectations.
+- `PRIVACY.md` for data handling principles and security reporting.
+- `docs/architecture.md` for planned layers and integration boundaries.
+- `docs/tdlib-adapter.md` for TDLib adapter and credential handling rules.
+- `docs/release-strategy.md` for release metadata policy.
+- `docs/backlog.md` and `config/epic-subtasks.json` for planned foundation work.

--- a/scripts/validate-foundation.mjs
+++ b/scripts/validate-foundation.mjs
@@ -7,6 +7,7 @@ const root = new URL('../', import.meta.url);
 
 const requiredFiles = [
   'README.md',
+  'CONTRIBUTING.md',
   'PRIVACY.md',
   'BUILD-GUIDE.md',
   'LICENSE',
@@ -110,7 +111,33 @@ for (const subtask of manifest.subtasks) {
   assert.ok(Array.isArray(subtask.acceptanceCriteria) && subtask.acceptanceCriteria.length >= 2);
 }
 
-const docsToScan = ['README.md', 'PRIVACY.md', 'BUILD-GUIDE.md', 'docs/architecture.md', 'docs/tdlib-adapter.md'];
+const contributing = await readFile(new URL('CONTRIBUTING.md', root), 'utf8');
+const requiredContributingPatterns = [
+  /npm test/,
+  /npm run validate:foundation/,
+  /npm run validate:release/,
+  /npm run decompose:dry-run/,
+  /docs\/contributing-templates\.md/,
+  /BUILD-GUIDE\.md/,
+  /PRIVACY\.md/,
+  /secrets/i,
+  /credentials/i,
+  /Telegram API IDs or hashes/i,
+  /private message content/i
+];
+
+for (const pattern of requiredContributingPatterns) {
+  assert.match(contributing, pattern, `CONTRIBUTING.md must include ${pattern}`);
+}
+
+const docsToScan = [
+  'README.md',
+  'CONTRIBUTING.md',
+  'PRIVACY.md',
+  'BUILD-GUIDE.md',
+  'docs/architecture.md',
+  'docs/tdlib-adapter.md'
+];
 const forbiddenPatterns = [
   /api_hash\s*[:=]\s*['"][^'"]+['"]/i,
   /api_id\s*[:=]\s*\d{4,}/i,


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` with local setup, validation, issue selection, branch, commit, PR, review, and security guidance.
- Link contributor guidance to the existing templates, build guide, privacy policy, architecture, TDLib adapter, release strategy, backlog, and epic manifest.
- Extend foundation validation so `CONTRIBUTING.md` is required, checked for key guidance, and scanned for secret-like values.

## Issue

Fixes #37

## Tests

- [x] `npm test`
- [x] `npm run validate:foundation`
- [x] `npm run validate:release`
- [x] `npm run decompose:dry-run`

## Risk

- Documentation-only change with low runtime risk.
- Foundation validation now includes contributor guidance checks, so future edits that remove required contributor guidance will fail CI.

## Screenshots or recordings

Not applicable.

## Security and privacy

- [x] This PR does not include secrets, production credentials, access tokens, Telegram API hashes, private keys, or private message content.
- [x] Any logs, screenshots, or fixtures are redacted.
