### PR TITLE
[009] Configure automated changelog generation

### DIFF
--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -28,3 +28,5 @@ jobs:
 
       - name: Preview generated changelog
         run: npm run changelog
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -25,3 +25,6 @@ jobs:
 
       - name: Validate release metadata
         run: npm run validate:release
+
+      - name: Preview generated changelog
+        run: npm run changelog

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-25T05:31:02.632Z for PR creation at branch issue-36-6d9d01a2c72e for issue https://github.com/xlabtg/Teleton-Client/issues/36
+# Updated: 2026-04-25T05:37:48.333Z

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+Release notes are generated from merged pull requests, then reviewed before publication.
+
+## [0.1.0] - 2026-04-25
+
+> Review required before publication: confirm titles and linked issues contain no private data, secrets, credentials, tokens, Telegram API hashes, private keys, or private message content.
+
+### Maintenance
+- Build Teleton foundation and epic decomposition ([#2](https://github.com/xlabtg/Teleton-Client/pull/2))
+- Publish epic decomposition issues ([#4](https://github.com/xlabtg/Teleton-Client/pull/4); refs #3)
+- Add foundation pre-commit workflow ([#30](https://github.com/xlabtg/Teleton-Client/pull/30); refs #5)
+- Complete EPIC #1 subtask expansion ([#32](https://github.com/xlabtg/Teleton-Client/pull/32); refs #31)
+- [002] Integrate TDLib build plan and baseline client adapter ([#71](https://github.com/xlabtg/Teleton-Client/pull/71); refs #6)
+- Complete EPIC #1 subtask expansion ([#72](https://github.com/xlabtg/Teleton-Client/pull/72); refs #31)
+- [003] Implement cross-platform settings model ([#73](https://github.com/xlabtg/Teleton-Client/pull/73); refs #7)
+- [004] Configure pre-commit hook checks ([#74](https://github.com/xlabtg/Teleton-Client/pull/74); refs #33)
+- [005] Add pull request and issue templates ([#75](https://github.com/xlabtg/Teleton-Client/pull/75); refs #34)
+- [006] Configure automated semantic versioning ([#76](https://github.com/xlabtg/Teleton-Client/pull/76); refs #35)
+- Add CODEOWNERS for reviewer assignment ([#77](https://github.com/xlabtg/Teleton-Client/pull/77); refs #36)
+- Add CONTRIBUTING.md contributor guidelines ([#78](https://github.com/xlabtg/Teleton-Client/pull/78); refs #37)

--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -24,6 +24,15 @@ The helper `classifyVersionBump(previousVersion, nextVersion)` records these rul
 ## Automation Rules
 
 - CI runs `npm run validate:release` for pull requests and pushes to `main` or `issue-*` branches.
+- CI previews generated changelog notes with `npm run changelog` so reviewers can inspect the release-note format before publication.
 - Release validation checks metadata consistency and stable semantic version syntax.
 - Publishing is intentionally absent from pull request workflows, so unreviewed pull request code cannot publish packages.
 - Future publishing automation should run only from reviewed `main` changes or protected release tags.
+
+## Changelog Workflow
+
+Run `npm run changelog` to print release notes for the current `package.json` version from merged pull requests on `main`. The generated notes group entries by pull request labels and include links to merged pull requests plus issue references found in pull request text such as `Fixes #38`.
+
+Run `npm run changelog:write -- --version 0.2.0` to prepend generated notes to `CHANGELOG.md`. The script redacts common token formats in pull request titles, but maintainers must review the generated notes before publishing and confirm that titles, links, logs, and references do not expose secrets, Telegram API hashes, private keys, production credentials, or private message content.
+
+Use `npm run changelog:check` in release preparation after `CHANGELOG.md` has been reviewed. The check fails when the reviewed changelog does not contain the generated release-note lines for the target version.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "prepare:hooks": "git config core.hooksPath .githooks",
     "validate:foundation": "node scripts/validate-foundation.mjs",
     "validate:release": "node scripts/validate-release.mjs",
+    "changelog": "node scripts/generate-changelog.mjs",
+    "changelog:write": "node scripts/generate-changelog.mjs --write",
+    "changelog:check": "node scripts/generate-changelog.mjs --check",
     "decompose:dry-run": "node scripts/decompose-epic.mjs --dry-run"
   },
   "engines": {

--- a/scripts/generate-changelog.mjs
+++ b/scripts/generate-changelog.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+import { readFile, writeFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+
+import { prependReleaseNotes, renderReleaseNotes } from '../src/foundation/changelog.mjs';
+
+const args = parseArgs(process.argv.slice(2));
+const root = new URL('../', import.meta.url);
+const packageJson = JSON.parse(await readFile(new URL('package.json', root), 'utf8'));
+const version = args.version ?? packageJson.version;
+const date = args.date ?? new Date().toISOString().slice(0, 10);
+const changelogPath = new URL(args.output ?? 'CHANGELOG.md', root);
+const entries = args.input ? await readEntriesFromFile(args.input) : listMergedPullRequests(args);
+const releaseNotes = renderReleaseNotes({ version, date, entries });
+
+if (args.check) {
+  assertChangelogContains(await readOptional(changelogPath), releaseNotes, version);
+  console.log(`Changelog contains reviewed release notes for ${version}.`);
+} else if (args.write) {
+  const existing = await readOptional(changelogPath);
+  await writeFile(changelogPath, prependReleaseNotes(existing, releaseNotes));
+  console.log(`Wrote release notes for ${version} to ${args.output ?? 'CHANGELOG.md'}.`);
+} else {
+  process.stdout.write(releaseNotes);
+}
+
+function parseArgs(argv) {
+  const parsed = { write: false, check: false };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--write') {
+      parsed.write = true;
+    } else if (arg === '--check') {
+      parsed.check = true;
+    } else if (arg === '--repo') {
+      parsed.repo = requiredValue(argv, index += 1, '--repo');
+    } else if (arg === '--version') {
+      parsed.version = requiredValue(argv, index += 1, '--version');
+    } else if (arg === '--date') {
+      parsed.date = requiredValue(argv, index += 1, '--date');
+    } else if (arg === '--since-tag') {
+      parsed.sinceTag = requiredValue(argv, index += 1, '--since-tag');
+    } else if (arg === '--base') {
+      parsed.base = requiredValue(argv, index += 1, '--base');
+    } else if (arg === '--input') {
+      parsed.input = requiredValue(argv, index += 1, '--input');
+    } else if (arg === '--output') {
+      parsed.output = requiredValue(argv, index += 1, '--output');
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (parsed.write && parsed.check) {
+    throw new Error('Choose either --write or --check, not both.');
+  }
+
+  return parsed;
+}
+
+function requiredValue(argv, index, flag) {
+  if (!argv[index]) {
+    throw new Error(`${flag} requires a value`);
+  }
+
+  return argv[index];
+}
+
+async function readEntriesFromFile(relativePath) {
+  const raw = await readFile(new URL(relativePath, root), 'utf8');
+  return JSON.parse(raw);
+}
+
+async function readOptional(url) {
+  try {
+    return await readFile(url, 'utf8');
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      return '';
+    }
+    throw error;
+  }
+}
+
+function listMergedPullRequests(options) {
+  const repo = options.repo ?? githubRepository();
+  const search = [`repo:${repo}`, 'is:pr', 'is:merged'];
+
+  if (options.sinceTag) {
+    search.push(`merged:>=${tagDate(options.sinceTag)}`);
+  }
+
+  const result = spawnSync(
+    'gh',
+    [
+      'pr',
+      'list',
+      '--repo',
+      repo,
+      '--state',
+      'merged',
+      '--base',
+      options.base ?? 'main',
+      '--limit',
+      '100',
+      '--search',
+      search.join(' '),
+      '--json',
+      'number,title,url,body,labels,mergeCommit'
+    ],
+    { encoding: 'utf8' }
+  );
+
+  if (result.status !== 0) {
+    throw new Error(`Failed to list merged pull requests: ${result.stderr || result.stdout}`);
+  }
+
+  return JSON.parse(result.stdout).map((entry) => ({
+    ...entry,
+    mergeCommitMessage: entry.mergeCommit?.message ?? ''
+  }));
+}
+
+function githubRepository() {
+  const result = spawnSync('gh', ['repo', 'view', '--json', 'nameWithOwner', '--jq', '.nameWithOwner'], {
+    encoding: 'utf8'
+  });
+
+  if (result.status !== 0) {
+    throw new Error(`Unable to detect GitHub repository: ${result.stderr || result.stdout}`);
+  }
+
+  return result.stdout.trim();
+}
+
+function tagDate(tag) {
+  const result = spawnSync('git', ['log', '-1', '--format=%cs', tag], { encoding: 'utf8' });
+
+  if (result.status !== 0 || !result.stdout.trim()) {
+    throw new Error(`Unable to resolve date for tag ${tag}`);
+  }
+
+  return result.stdout.trim();
+}
+
+function assertChangelogContains(changelog, releaseNotes, version) {
+  if (!changelog.includes(`## [${version}]`)) {
+    throw new Error(`CHANGELOG.md must include reviewed release notes for ${version}`);
+  }
+
+  const requiredLines = releaseNotes
+    .split('\n')
+    .filter((line) => line.startsWith('- ') || line.startsWith('> Review required'));
+
+  for (const line of requiredLines) {
+    if (!changelog.includes(line)) {
+      throw new Error(`CHANGELOG.md is missing generated line: ${line}`);
+    }
+  }
+}

--- a/scripts/validate-release.mjs
+++ b/scripts/validate-release.mjs
@@ -6,6 +6,7 @@ import { RELEASE_METADATA, VERSION_SOURCE_OF_TRUTH, isStableSemver } from '../sr
 
 const root = new URL('../', import.meta.url);
 const packageJson = JSON.parse(await readFile(new URL('package.json', root), 'utf8'));
+const changelog = await readFile(new URL('CHANGELOG.md', root), 'utf8');
 
 assert.equal(VERSION_SOURCE_OF_TRUTH, 'package.json', 'package.json must be the documented version source of truth');
 assert.equal(RELEASE_METADATA.sourceOfTruth, VERSION_SOURCE_OF_TRUTH, 'release metadata must name its source of truth');
@@ -14,5 +15,7 @@ assert.equal(RELEASE_METADATA.version, packageJson.version, 'release metadata ve
 assert.equal(RELEASE_METADATA.private, packageJson.private, 'release metadata private flag must match package.json');
 assert.equal(isStableSemver(packageJson.version), true, 'package.json version must be stable semantic version MAJOR.MINOR.PATCH');
 assert.equal(packageJson.private, true, 'foundation package must remain private until reviewed release automation is added');
+assert.match(changelog, /^# Changelog/m, 'CHANGELOG.md must be present for reviewed release notes');
+assert.match(changelog, /reviewed before publication/i, 'CHANGELOG.md must document manual review before publishing');
 
 console.log(`Release validation passed for ${packageJson.name}@${packageJson.version}.`);

--- a/src/foundation/changelog.mjs
+++ b/src/foundation/changelog.mjs
@@ -1,0 +1,156 @@
+const VERSION_HEADING_PATTERN = /^## \[(?<version>\d+\.\d+\.\d+)] - (?<date>\d{4}-\d{2}-\d{2})$/m;
+
+export const CHANGELOG_SECTIONS = ['Breaking Changes', 'Features', 'Fixes', 'Documentation', 'Maintenance'];
+
+export function normalizeReleaseEntry(entry) {
+  const number = Number(entry.number);
+  const title = String(entry.title ?? '').trim();
+  const url = String(entry.url ?? '').trim();
+  const labels = Array.isArray(entry.labels) ? entry.labels.map(normalizeLabel) : [];
+
+  if (!Number.isInteger(number) || number <= 0) {
+    throw new Error('Release entry number must be a positive integer');
+  }
+
+  if (!title) {
+    throw new Error(`Release entry #${number} must have a title`);
+  }
+
+  if (!url) {
+    throw new Error(`Release entry #${number} must have a URL`);
+  }
+
+  return {
+    number,
+    title: redactPrivateData(title),
+    url,
+    labels,
+    issues: extractIssueReferences(entry)
+  };
+}
+
+export function renderReleaseNotes({ version, date, entries }) {
+  if (!isStableVersion(version)) {
+    throw new Error('Release notes version must use MAJOR.MINOR.PATCH format');
+  }
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    throw new Error('Release notes date must use YYYY-MM-DD format');
+  }
+
+  const normalizedEntries = entries.map(normalizeReleaseEntry);
+  const grouped = groupEntriesBySection(normalizedEntries);
+  const lines = [
+    `## [${version}] - ${date}`,
+    '',
+    '> Review required before publication: confirm titles and linked issues contain no private data, secrets, credentials, tokens, Telegram API hashes, private keys, or private message content.',
+    ''
+  ];
+
+  for (const section of CHANGELOG_SECTIONS) {
+    const sectionEntries = grouped.get(section) ?? [];
+    if (sectionEntries.length === 0) {
+      continue;
+    }
+
+    lines.push(`### ${section}`);
+    for (const entry of sectionEntries) {
+      const issueLinks = entry.issues.length > 0 ? `; refs ${entry.issues.join(', ')}` : '';
+      lines.push(`- ${entry.title} ([#${entry.number}](${entry.url})${issueLinks})`);
+    }
+    lines.push('');
+  }
+
+  return `${lines.join('\n').trimEnd()}\n`;
+}
+
+export function prependReleaseNotes(existingChangelog, releaseNotes) {
+  if (!existingChangelog.trim()) {
+    return `# Changelog\n\n${releaseNotes}`;
+  }
+
+  const heading = releaseNotes.match(VERSION_HEADING_PATTERN);
+  if (!heading) {
+    throw new Error('Release notes must start with a version heading');
+  }
+
+  if (existingChangelog.includes(heading[0])) {
+    throw new Error(`Changelog already contains ${heading[0]}`);
+  }
+
+  const insertionPoint = existingChangelog.indexOf('\n## ');
+  if (insertionPoint === -1) {
+    return `${existingChangelog.trimEnd()}\n\n${releaseNotes}`;
+  }
+
+  return `${existingChangelog.slice(0, insertionPoint).trimEnd()}\n\n${releaseNotes}${existingChangelog.slice(insertionPoint + 1)}`;
+}
+
+export function groupEntriesBySection(entries) {
+  const grouped = new Map(CHANGELOG_SECTIONS.map((section) => [section, []]));
+
+  for (const entry of entries) {
+    grouped.get(sectionForEntry(entry)).push(entry);
+  }
+
+  for (const sectionEntries of grouped.values()) {
+    sectionEntries.sort((left, right) => left.number - right.number);
+  }
+
+  return grouped;
+}
+
+function sectionForEntry(entry) {
+  const labels = new Set(entry.labels);
+
+  if (labels.has('breaking-change') || labels.has('major')) {
+    return 'Breaking Changes';
+  }
+
+  if (labels.has('feature') || labels.has('enhancement')) {
+    return 'Features';
+  }
+
+  if (labels.has('bug') || labels.has('fix')) {
+    return 'Fixes';
+  }
+
+  if (labels.has('documentation') || labels.has('docs')) {
+    return 'Documentation';
+  }
+
+  return 'Maintenance';
+}
+
+function extractIssueReferences(entry) {
+  const references = new Set();
+  const fields = [entry.body, entry.mergeCommitMessage, entry.title].filter(Boolean);
+
+  for (const field of fields) {
+    const matches = String(field).matchAll(/\b(?:fixes|closes|resolves|refs|references)\s+#(?<number>\d+)/gi);
+    for (const match of matches) {
+      references.add(`#${match.groups.number}`);
+    }
+  }
+
+  return [...references].sort((left, right) => Number(left.slice(1)) - Number(right.slice(1)));
+}
+
+function normalizeLabel(label) {
+  if (typeof label === 'string') {
+    return label.toLowerCase();
+  }
+
+  return String(label.name ?? '').toLowerCase();
+}
+
+function redactPrivateData(value) {
+  return value
+    .replace(/gh[pousr]_[A-Za-z0-9_]{20,}/g, '[REDACTED_TOKEN]')
+    .replace(/xox[baprs]-[A-Za-z0-9-]{20,}/g, '[REDACTED_TOKEN]')
+    .replace(/\b\d{5,}:[A-Za-z0-9_-]{20,}\b/g, '[REDACTED_TOKEN]');
+}
+
+function isStableVersion(version) {
+  return /^\d+\.\d+\.\d+$/.test(version);
+}

--- a/test/changelog.test.mjs
+++ b/test/changelog.test.mjs
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { prependReleaseNotes, renderReleaseNotes } from '../src/foundation/changelog.mjs';
+
+test('release notes group merged pull requests and link referenced issues', () => {
+  const notes = renderReleaseNotes({
+    version: '0.2.0',
+    date: '2026-04-25',
+    entries: [
+      {
+        number: 12,
+        title: 'Document release process',
+        url: 'https://github.com/xlabtg/Teleton-Client/pull/12',
+        labels: [{ name: 'documentation' }],
+        body: 'Fixes #9'
+      },
+      {
+        number: 10,
+        title: 'Add proxy settings',
+        url: 'https://github.com/xlabtg/Teleton-Client/pull/10',
+        labels: [{ name: 'enhancement' }],
+        body: 'Refs #3'
+      }
+    ]
+  });
+
+  assert.match(notes, /^## \[0\.2\.0] - 2026-04-25/m);
+  assert.match(notes, /Review required before publication/);
+  assert.match(notes, /### Features\n- Add proxy settings \(\[#10]\(https:\/\/github.com\/xlabtg\/Teleton-Client\/pull\/10\); refs #3\)/);
+  assert.match(notes, /### Documentation\n- Document release process \(\[#12]\(https:\/\/github.com\/xlabtg\/Teleton-Client\/pull\/12\); refs #9\)/);
+});
+
+test('release notes redact common token formats from pull request titles', () => {
+  const notes = renderReleaseNotes({
+    version: '0.1.1',
+    date: '2026-04-25',
+    entries: [
+      {
+        number: 14,
+        title: 'Remove leaked ghp_abcdefghijklmnopqrstuvwxyz1234567890 token',
+        url: 'https://github.com/xlabtg/Teleton-Client/pull/14',
+        labels: ['security']
+      }
+    ]
+  });
+
+  assert.doesNotMatch(notes, /ghp_/);
+  assert.match(notes, /\[REDACTED_TOKEN]/);
+});
+
+test('release notes can be prepended without replacing existing reviewed entries', () => {
+  const existing = '# Changelog\n\n## [0.1.0] - 2026-04-01\n\n### Maintenance\n- Initial foundation ([#1](https://github.com/xlabtg/Teleton-Client/pull/1))\n';
+  const next = renderReleaseNotes({
+    version: '0.1.1',
+    date: '2026-04-25',
+    entries: [
+      {
+        number: 2,
+        title: 'Validate release metadata',
+        url: 'https://github.com/xlabtg/Teleton-Client/pull/2',
+        labels: ['ci']
+      }
+    ]
+  });
+
+  const updated = prependReleaseNotes(existing, next);
+
+  assert.match(updated, /^# Changelog\n\n## \[0\.1\.1] - 2026-04-25/);
+  assert.match(updated, /## \[0\.1\.0] - 2026-04-01/);
+  assert.throws(() => prependReleaseNotes(updated, next), /already contains/);
+});

--- a/test/foundation.test.mjs
+++ b/test/foundation.test.mjs
@@ -19,6 +19,7 @@ test('foundation artifacts required by issue 1 are present', () => {
     'PRIVACY.md',
     'BUILD-GUIDE.md',
     'LICENSE',
+    'CHANGELOG.md',
     '.githooks/pre-commit',
     '.github/workflows/ci.yml',
     '.github/workflows/release-validation.yml',

--- a/test/release-metadata.test.mjs
+++ b/test/release-metadata.test.mjs
@@ -38,4 +38,18 @@ test('release workflow does not publish from pull request events', async () => {
   assert.doesNotMatch(workflow, /^\s*release:/m, 'validation workflow should not publish packages');
   assert.doesNotMatch(workflow, /npm\s+publish/, 'pull request workflow must not publish packages');
   assert.match(workflow, /npm run validate:release/, 'workflow should validate release metadata');
+  assert.match(workflow, /npm run changelog/, 'workflow should preview generated changelog notes');
+});
+
+test('release documentation includes reviewed changelog generation workflow', async () => {
+  const packageJson = JSON.parse(await readFile(new URL('package.json', root), 'utf8'));
+  const releaseStrategy = await readFile(new URL('docs/release-strategy.md', root), 'utf8');
+  const changelog = await readFile(new URL('CHANGELOG.md', root), 'utf8');
+
+  assert.equal(packageJson.scripts.changelog, 'node scripts/generate-changelog.mjs');
+  assert.equal(packageJson.scripts['changelog:write'], 'node scripts/generate-changelog.mjs --write');
+  assert.equal(packageJson.scripts['changelog:check'], 'node scripts/generate-changelog.mjs --check');
+  assert.match(releaseStrategy, /merged pull requests/i);
+  assert.match(releaseStrategy, /manual review|review.*before publishing/i);
+  assert.match(changelog, /reviewed before publication/i);
 });


### PR DESCRIPTION
## Summary

- Add a changelog generator that builds reviewed release notes from merged pull requests.
- Add npm scripts for previewing, writing, and checking changelog entries.
- Wire changelog preview into release validation CI and document the manual review workflow.

## Issue

Fixes #38

## Tests

- [x] npm test
- [x] npm run validate:foundation
- [x] npm run validate:release
- [x] npm run changelog:check

## Risk

- The generator reads merged pull request metadata through GitHub CLI; maintainers still review generated notes before publication.

## Screenshots or recordings

Not applicable.

## Security and privacy

- [x] This PR does not include secrets, production credentials, access tokens, Telegram API hashes, private keys, or private message content.
- [x] Generated release notes include an explicit privacy review gate before publication.