### PR TITLE
Integrate MTProto and SOCKS5 proxy settings with TDLib

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-25T05:31:02.632Z for PR creation at branch issue-36-6d9d01a2c72e for issue https://github.com/xlabtg/Teleton-Client/issues/36
 # Updated: 2026-04-25T05:35:31.325Z
+# Updated: 2026-04-25T06:01:31.657Z

--- a/docs/tdlib-adapter.md
+++ b/docs/tdlib-adapter.md
@@ -11,12 +11,19 @@ The shared TDLib adapter is the first boundary between platform callers and a fu
 
 ## Contract
 
-The adapter exposes four operations:
+The adapter exposes core client operations:
 
 - `authenticate(request)` validates Telegram credential references before the platform bridge begins TDLib authorization.
 - `getChatList(query)` returns a bounded page of chats with an adapter-owned cursor.
 - `sendMessage(draft)` validates chat and text inputs before the platform bridge sends a message.
 - `subscribeUpdates(listener, options)` registers a typed update listener and returns an unsubscribe function.
+
+The adapter also exposes proxy lifecycle operations that build TDLib-compatible commands before the native bridge sends them:
+
+- `enableProxy(config)` validates MTProto or SOCKS5 settings and maps them to `addProxy`.
+- `updateProxy(proxyId, config)` validates an existing TDLib proxy id and maps settings to `editProxy`.
+- `disableProxy()` maps to `disableProxy`.
+- `removeProxy(proxyId)` validates the TDLib proxy id and maps to `removeProxy`.
 
 Authentication accepts secure references only:
 
@@ -30,9 +37,11 @@ Authentication accepts secure references only:
 
 The shared adapter rejects raw `apiId`, `api_id`, `apiHash`, `api_hash`, `phoneNumber`, and `botToken` values. Platform bridges are responsible for resolving references through environment variables, keychains, keystores, secret managers, or equivalent local secure storage.
 
+Proxy settings follow the same rule. MTProto requires `secretRef`, while SOCKS5 accepts optional `usernameRef` and `passwordRef`. Raw proxy secrets and credentials are rejected before native bridge calls. Platform bridges must resolve those references inside platform secure storage and pass the resolved values only to TDLib-native APIs, never back through shared logs or command snapshots.
+
 ## Mock Testing
 
-`createMockTdlibClientAdapter` implements the same public contract without TDLib, Telegram network access, phone numbers, bot tokens, or live user credentials. Tests can seed chat fixtures, send mock messages, and subscribe to mock updates while preserving the same validation path used by native bridge adapters.
+`createMockTdlibClientAdapter` implements the same public contract without TDLib, Telegram network access, phone numbers, bot tokens, proxy secrets, or live user credentials. Tests can seed chat fixtures, send mock messages, subscribe to mock updates, and verify proxy command mapping while preserving the same validation path used by native bridge adapters.
 
 ## Build Targets
 

--- a/src/tdlib/client-adapter.mjs
+++ b/src/tdlib/client-adapter.mjs
@@ -4,6 +4,7 @@ export const TDLIB_PLATFORMS = Object.freeze(['android', 'ios', 'desktop', 'web'
 export const TDLIB_UPDATE_TYPES = Object.freeze(['authorizationState', 'connectionState', 'chatList', 'message']);
 
 const REQUIRED_IMPLEMENTATION_METHODS = ['authenticate', 'getChatList', 'sendMessage', 'subscribeUpdates'];
+const OPTIONAL_PROXY_METHODS = ['enableProxy', 'updateProxy', 'disableProxy', 'removeProxy'];
 const MAX_CHAT_LIST_LIMIT = 100;
 const MAX_MESSAGE_TEXT_LENGTH = 4096;
 
@@ -41,6 +42,17 @@ function assertBridgeImplementation(implementation) {
       `TDLib adapter implementation is missing methods: ${missingMethods.join(', ')}.`,
       'invalid_implementation',
       missingMethods
+    );
+  }
+
+  const invalidProxyMethods = OPTIONAL_PROXY_METHODS.filter(
+    (method) => implementation[method] !== undefined && typeof implementation[method] !== 'function'
+  );
+  if (invalidProxyMethods.length > 0) {
+    throw new TdlibAdapterError(
+      `TDLib adapter proxy implementation methods must be functions: ${invalidProxyMethods.join(', ')}.`,
+      'invalid_implementation',
+      invalidProxyMethods
     );
   }
 }
@@ -141,6 +153,131 @@ export function validateTdlibMessageDraft(input = {}) {
   };
 }
 
+export function validateTdlibProxyConfig(input = {}) {
+  const errors = [];
+  const protocol = String(input.protocol ?? '').trim().toLowerCase();
+  const host = String(input.host ?? '').trim();
+  const port = input.port;
+  const proxy = {
+    protocol,
+    host,
+    port
+  };
+
+  if (!['mtproto', 'socks5'].includes(protocol)) {
+    errors.push(`Unsupported proxy protocol: ${input.protocol}`);
+  }
+
+  if (!host) {
+    errors.push('Proxy host is required.');
+  }
+
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    errors.push('Proxy port must be an integer between 1 and 65535.');
+  }
+
+  if (protocol === 'mtproto') {
+    const secretRef = input.secretRef ?? input.secret;
+    if (!isSecureReference(secretRef)) {
+      errors.push('MTProto secretRef must be a secure reference such as env:TELETON_MTPROTO_SECRET.');
+    } else {
+      proxy.secretRef = secretRef;
+    }
+  }
+
+  if (protocol === 'socks5') {
+    for (const field of ['username', 'password']) {
+      const refField = `${field}Ref`;
+      const value = input[refField] ?? input[field];
+      if (value === undefined) {
+        continue;
+      }
+
+      if (!isSecureReference(value)) {
+        errors.push(`SOCKS5 ${refField} must be a secure reference when provided.`);
+      } else {
+        proxy[refField] = value;
+      }
+    }
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    proxy
+  };
+}
+
+function validateProxyId(proxyId) {
+  const errors = [];
+  if (!Number.isInteger(proxyId) || proxyId < 1) {
+    errors.push('TDLib proxy id must be a positive integer.');
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    proxyId
+  };
+}
+
+function proxyTypeFor(proxy) {
+  if (proxy.protocol === 'mtproto') {
+    return {
+      '@type': 'proxyTypeMtproto',
+      secretRef: proxy.secretRef
+    };
+  }
+
+  const type = {
+    '@type': 'proxyTypeSocks5'
+  };
+
+  if (proxy.usernameRef !== undefined) {
+    type.usernameRef = proxy.usernameRef;
+  }
+
+  if (proxy.passwordRef !== undefined) {
+    type.passwordRef = proxy.passwordRef;
+  }
+
+  return type;
+}
+
+export function createTdlibAddProxyCommand(proxy) {
+  return {
+    '@type': 'addProxy',
+    server: proxy.host,
+    port: proxy.port,
+    enable: true,
+    type: proxyTypeFor(proxy)
+  };
+}
+
+export function createTdlibEditProxyCommand(proxyId, proxy) {
+  return {
+    '@type': 'editProxy',
+    proxy_id: proxyId,
+    server: proxy.host,
+    port: proxy.port,
+    enable: true,
+    type: proxyTypeFor(proxy)
+  };
+}
+
+export function createTdlibDisableProxyCommand() {
+  return {
+    '@type': 'disableProxy'
+  };
+}
+
+export function createTdlibRemoveProxyCommand(proxyId) {
+  return {
+    '@type': 'removeProxy',
+    proxy_id: proxyId
+  };
+}
+
 function validateUpdateSubscription(listener, input = {}) {
   const errors = [];
 
@@ -214,6 +351,55 @@ export function createTdlibClientAdapter(implementation, options = {}) {
       }
 
       return unsubscribe;
+    },
+    async enableProxy(input = {}) {
+      const validation = validateTdlibProxyConfig(input);
+      if (!validation.valid) {
+        throw adapterError(validation.errors, 'invalid_proxy_config');
+      }
+
+      const command = createTdlibAddProxyCommand(validation.proxy);
+      if (typeof implementation.enableProxy !== 'function') {
+        return command;
+      }
+
+      return implementation.enableProxy(command);
+    },
+    async updateProxy(proxyId, input = {}) {
+      const idValidation = validateProxyId(proxyId);
+      const proxyValidation = validateTdlibProxyConfig(input);
+      const errors = [...idValidation.errors, ...proxyValidation.errors];
+      if (errors.length > 0) {
+        throw adapterError(errors, 'invalid_proxy_config');
+      }
+
+      const command = createTdlibEditProxyCommand(idValidation.proxyId, proxyValidation.proxy);
+      if (typeof implementation.updateProxy !== 'function') {
+        return command;
+      }
+
+      return implementation.updateProxy(idValidation.proxyId, command);
+    },
+    async disableProxy() {
+      const command = createTdlibDisableProxyCommand();
+      if (typeof implementation.disableProxy !== 'function') {
+        return command;
+      }
+
+      return implementation.disableProxy(command);
+    },
+    async removeProxy(proxyId) {
+      const validation = validateProxyId(proxyId);
+      if (!validation.valid) {
+        throw adapterError(validation.errors, 'invalid_proxy_id');
+      }
+
+      const command = createTdlibRemoveProxyCommand(validation.proxyId);
+      if (typeof implementation.removeProxy !== 'function') {
+        return command;
+      }
+
+      return implementation.removeProxy(validation.proxyId, command);
     }
   });
 }
@@ -236,6 +422,7 @@ export function createMockTdlibClientAdapter(seed = {}) {
   const commands = [];
   const subscribers = new Set();
   let nextMessageId = 1;
+  let nextProxyId = 1;
 
   function publish(update) {
     for (const subscription of subscribers) {
@@ -291,6 +478,25 @@ export function createMockTdlibClientAdapter(seed = {}) {
       return () => {
         subscribers.delete(subscriber);
       };
+    },
+    async enableProxy(command) {
+      commands.push({ method: 'enableProxy', command: structuredClone(command) });
+      const proxyId = nextProxyId;
+      nextProxyId += 1;
+
+      return { proxyId };
+    },
+    async updateProxy(proxyId, command) {
+      commands.push({ method: 'updateProxy', proxyId, command: structuredClone(command) });
+      return { proxyId };
+    },
+    async disableProxy(command) {
+      commands.push({ method: 'disableProxy', command: structuredClone(command) });
+      return { disabled: true };
+    },
+    async removeProxy(proxyId, command) {
+      commands.push({ method: 'removeProxy', proxyId, command: structuredClone(command) });
+      return { proxyId, removed: true };
     }
   };
 

--- a/test/tdlib-adapter.test.mjs
+++ b/test/tdlib-adapter.test.mjs
@@ -6,7 +6,8 @@ import {
   TDLIB_PLATFORMS,
   createMockTdlibClientAdapter,
   createTdlibClientAdapter,
-  validateTdlibAuthenticationRequest
+  validateTdlibAuthenticationRequest,
+  validateTdlibProxyConfig
 } from '../src/tdlib/client-adapter.mjs';
 
 const root = new URL('../', import.meta.url);
@@ -133,6 +134,121 @@ test('TDLib client adapter validates bridge inputs before native calls', async (
     { method: 'subscribeUpdates' },
     { method: 'unsubscribe' }
   ]);
+});
+
+test('TDLib proxy commands map MTProto and SOCKS5 settings without plaintext secrets', async () => {
+  const adapter = createMockTdlibClientAdapter();
+
+  const mtproto = await adapter.enableProxy({
+    protocol: 'mtproto',
+    host: 'mtproto.example',
+    port: 443,
+    secretRef: 'env:TELETON_MTPROTO_SECRET'
+  });
+  const socks5 = await adapter.updateProxy(mtproto.proxyId, {
+    protocol: 'socks5',
+    host: '127.0.0.1',
+    port: 1080,
+    usernameRef: 'keychain:proxy-user',
+    passwordRef: 'keychain:proxy-password'
+  });
+
+  await adapter.disableProxy();
+  await adapter.removeProxy(socks5.proxyId);
+
+  assert.deepEqual(adapter.getCommands().slice(-4), [
+    {
+      method: 'enableProxy',
+      command: {
+        '@type': 'addProxy',
+        server: 'mtproto.example',
+        port: 443,
+        enable: true,
+        type: {
+          '@type': 'proxyTypeMtproto',
+          secretRef: 'env:TELETON_MTPROTO_SECRET'
+        }
+      }
+    },
+    {
+      method: 'updateProxy',
+      proxyId: mtproto.proxyId,
+      command: {
+        '@type': 'editProxy',
+        proxy_id: mtproto.proxyId,
+        server: '127.0.0.1',
+        port: 1080,
+        enable: true,
+        type: {
+          '@type': 'proxyTypeSocks5',
+          usernameRef: 'keychain:proxy-user',
+          passwordRef: 'keychain:proxy-password'
+        }
+      }
+    },
+    {
+      method: 'disableProxy',
+      command: {
+        '@type': 'disableProxy'
+      }
+    },
+    {
+      method: 'removeProxy',
+      proxyId: socks5.proxyId,
+      command: {
+        '@type': 'removeProxy',
+        proxy_id: socks5.proxyId
+      }
+    }
+  ]);
+
+  assert.doesNotMatch(JSON.stringify(adapter.getCommands()), /hardcoded-secret|proxy-password-value/);
+});
+
+test('TDLib proxy validation rejects invalid settings before native calls', async () => {
+  const validation = validateTdlibProxyConfig({
+    protocol: 'mtproto',
+    host: 'proxy.example',
+    port: 443,
+    secret: 'hardcoded-secret'
+  });
+
+  assert.equal(validation.valid, false);
+  assert.match(validation.errors.join('\n'), /secure reference/);
+
+  const calls = [];
+  const adapter = createTdlibClientAdapter(
+    {
+      async authenticate() {
+        return { authorizationState: 'ready' };
+      },
+      async getChatList() {
+        return { chats: [], nextCursor: null };
+      },
+      async sendMessage() {
+        return { id: 'message-1', status: 'sent' };
+      },
+      subscribeUpdates() {
+        return () => {};
+      },
+      async enableProxy(command) {
+        calls.push(command);
+        return { proxyId: 1 };
+      }
+    }
+  );
+
+  await assert.rejects(
+    () => adapter.enableProxy({
+      protocol: 'socks5',
+      host: '',
+      port: 70000,
+      password: 'raw-password'
+    }),
+    /Proxy host/
+  );
+
+  assert.deepEqual(calls, []);
 });
 
 test('TDLib build targets, licensing, and adapter boundary are documented', async () => {


### PR DESCRIPTION
## Summary
- Add TDLib proxy validation and command builders for MTProto and SOCKS5 settings.
- Expose enable, update, disable, and remove proxy operations through the TDLib adapter boundary.
- Extend the mock TDLib adapter and tests so proxy commands are verified without native TDLib or plaintext secrets.
- Document platform secure-storage expectations for proxy references.

## Tests
- npm test
- npm run validate:foundation
- npm run validate:release
- npm run decompose:dry-run

Fixes #9