### PR TITLE
[012] Build proxy settings UI state

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-04-25T05:31:02.632Z for PR creation at branch issue-36-6d9d01a2c72e for issue https://github.com/xlabtg/Teleton-Client/issues/36
 # Updated: 2026-04-25T05:35:31.325Z
 # Updated: 2026-04-25T06:01:31.657Z
+# Updated: 2026-04-25T06:05:01.785Z

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This repository is in the foundation phase. The current implementation establish
 - Dry-run and idempotent GitHub issue creation script for decomposing issue `#1`.
 - Shared cross-platform settings model for language, theme, notifications, agent mode, proxy, and secure references.
 - ProxyManager route selection for direct, MTProto, and SOCKS5 connectivity using saved preferences and health inputs.
+- Shared proxy settings view state for add, test, enable, disable, edit, and remove workflows without exposing secure references.
 - Baseline TDLib client adapter contract with mock-backed tests.
 - CI workflow for foundation checks.
 - Documented semantic version source of truth and release metadata validation.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,6 +18,7 @@ Teleton Client is planned as a layered client where protocol, automation, wallet
 - TDLib callers use the shared `authenticate`, `getChatList`, `sendMessage`, and `subscribeUpdates` adapter contract so Android, iOS, desktop, and web-compatible bridges expose the same boundary.
 - Agent mode defaults to `off`; cloud and hybrid modes require explicit activation.
 - Proxy secrets are represented as secure references such as `env:NAME`, `keychain:name`, or `keystore:name`.
+- Proxy settings UI shells use shared view state for list items, edit forms, test status, and active route metadata. Display snapshots expose only configured flags for secrets, while settings persistence keeps secure references for platform storage resolution.
 - TON signing requires user confirmation and platform secure storage or wallet-provider approval.
 
 ## Foundation Status

--- a/src/foundation/proxy-settings-view.mjs
+++ b/src/foundation/proxy-settings-view.mjs
@@ -1,0 +1,275 @@
+import { createDirectRoute, createProxyManager } from './proxy-manager.mjs';
+import { validateProxyConfig } from './proxy-settings.mjs';
+
+const DEFAULT_DRAFT = Object.freeze({
+  id: '',
+  protocol: 'mtproto',
+  host: '',
+  port: '',
+  secretRef: '',
+  usernameRef: '',
+  passwordRef: ''
+});
+
+const SECURE_REFERENCE_PATTERN = /\b(?:env|keychain|keystore|secret):[A-Za-z0-9_.:/-]+/g;
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function sanitizeMessage(message) {
+  return String(message || 'Proxy test failed.').replaceAll(SECURE_REFERENCE_PATTERN, '[redacted]');
+}
+
+function normalizeId(value, protocol, host, port) {
+  const explicit = String(value ?? '').trim();
+  if (explicit) {
+    return explicit;
+  }
+
+  return `${protocol}-${host}-${port}`.toLowerCase().replaceAll(/[^a-z0-9_-]+/g, '-').replaceAll(/^-|-$/g, '');
+}
+
+function draftToConfig(draft) {
+  const protocol = String(draft.protocol ?? '').trim().toLowerCase();
+  const host = String(draft.host ?? '').trim();
+  const numericPort = Number(draft.port);
+  const port = Number.isInteger(numericPort) ? numericPort : draft.port;
+  const id = normalizeId(draft.id, protocol, host, port);
+  const config = { id, protocol, host, port };
+
+  for (const [draftField, configField] of [
+    ['secretRef', 'secret'],
+    ['usernameRef', 'username'],
+    ['passwordRef', 'password']
+  ]) {
+    const value = String(draft[draftField] ?? '').trim();
+    if (value) {
+      config[configField] = value;
+    }
+  }
+
+  return config;
+}
+
+function entryToDraft(entry = DEFAULT_DRAFT) {
+  return {
+    id: entry.id ?? '',
+    protocol: entry.protocol ?? 'mtproto',
+    host: entry.host ?? '',
+    port: entry.port === undefined ? '' : String(entry.port),
+    secretRef: entry.secretRef ?? '',
+    usernameRef: entry.usernameRef ?? '',
+    passwordRef: entry.passwordRef ?? ''
+  };
+}
+
+function validateDraft(draft) {
+  const config = draftToConfig(draft);
+  const validation = validateProxyConfig(config);
+
+  if (!config.id) {
+    validation.errors.unshift('Proxy id is required.');
+  }
+
+  return {
+    valid: validation.errors.length === 0,
+    errors: validation.errors,
+    entry: validation.errors.length === 0 ? { id: config.id, ...validation.config } : null
+  };
+}
+
+function listItem(entry, activeProxyId, enabled) {
+  const protocolName = entry.protocol === 'mtproto' ? 'MTProto' : 'SOCKS5';
+
+  return {
+    id: entry.id,
+    protocol: entry.protocol,
+    host: entry.host,
+    port: entry.port,
+    label: `${protocolName} ${entry.host}:${entry.port}`,
+    enabled: enabled === true && entry.id === activeProxyId,
+    secretConfigured: entry.secretRef !== undefined,
+    usernameConfigured: entry.usernameRef !== undefined,
+    passwordConfigured: entry.passwordRef !== undefined
+  };
+}
+
+function routeFromSettings(settings) {
+  if (settings.proxy.enabled !== true) {
+    return createDirectRoute();
+  }
+
+  const active = settings.proxy.entries.find((entry) => entry.id === settings.proxy.activeProxyId);
+  if (!active) {
+    return createDirectRoute();
+  }
+
+  const route = {
+    type: active.protocol,
+    proxyId: active.id,
+    host: active.host,
+    port: active.port,
+    secretConfigured: active.secretRef !== undefined,
+    usernameConfigured: active.usernameRef !== undefined,
+    passwordConfigured: active.passwordRef !== undefined
+  };
+
+  return Object.freeze(route);
+}
+
+function defaultProxyTest() {
+  return {
+    reachable: false,
+    message: 'No proxy test adapter is configured.'
+  };
+}
+
+export function createProxySettingsView(options = {}) {
+  const manager = createProxyManager(options.initialSettings);
+  const testProxyAdapter = options.testProxy ?? defaultProxyTest;
+  let draft = entryToDraft(options.draft);
+  let tests = {};
+
+  function state() {
+    const settings = manager.getSettings();
+    const form = validateDraft(draft);
+
+    return {
+      list: {
+        items: settings.proxy.entries.map((entry) => listItem(entry, settings.proxy.activeProxyId, settings.proxy.enabled))
+      },
+      form: {
+        draft: clone(draft),
+        valid: form.valid,
+        errors: [...form.errors]
+      },
+      tests: clone(tests),
+      route: routeFromSettings(settings)
+    };
+  }
+
+  function saveProxyEntries(entries, enabled = false, activeProxyId = null) {
+    return manager.saveProxyPreferences({
+      enabled,
+      activeProxyId,
+      entries
+    });
+  }
+
+  return Object.freeze({
+    getState() {
+      return state();
+    },
+    updateDraft(values = {}) {
+      draft = {
+        ...draft,
+        ...values
+      };
+      return state();
+    },
+    editProxy(proxyId) {
+      const settings = manager.getSettings();
+      const entry = settings.proxy.entries.find((item) => item.id === proxyId);
+      if (!entry) {
+        throw new Error(`Proxy ${proxyId} was not found.`);
+      }
+
+      draft = entryToDraft(entry);
+      return state();
+    },
+    saveDraft() {
+      const settings = manager.getSettings();
+      const validation = validateDraft(draft);
+
+      if (!validation.valid) {
+        throw new Error(validation.errors.join(' '));
+      }
+
+      const existingIndex = settings.proxy.entries.findIndex((entry) => entry.id === validation.entry.id);
+      const entries = [...settings.proxy.entries];
+      if (existingIndex === -1) {
+        entries.push(validation.entry);
+      } else {
+        entries[existingIndex] = validation.entry;
+      }
+
+      manager.saveProxyPreferences({
+        ...settings.proxy,
+        entries
+      });
+      draft = entryToDraft();
+
+      return state();
+    },
+    async testProxy(proxyId) {
+      const settings = manager.getSettings();
+      const entry = settings.proxy.entries.find((item) => item.id === proxyId);
+      if (!entry) {
+        throw new Error(`Proxy ${proxyId} was not found.`);
+      }
+
+      tests = {
+        ...tests,
+        [proxyId]: {
+          status: 'running',
+          message: 'Testing proxy connection...'
+        }
+      };
+
+      try {
+        const result = await testProxyAdapter(clone(entry));
+        tests = {
+          ...tests,
+          [proxyId]: {
+            status: result?.reachable === true ? 'success' : 'failure',
+            message: sanitizeMessage(result?.message ?? (result?.reachable === true ? 'Connected' : 'Proxy test failed.'))
+          }
+        };
+      } catch (error) {
+        tests = {
+          ...tests,
+          [proxyId]: {
+            status: 'failure',
+            message: sanitizeMessage(error.message)
+          }
+        };
+      }
+
+      return state();
+    },
+    enableProxy(proxyId) {
+      const settings = manager.getSettings();
+      if (!settings.proxy.entries.some((entry) => entry.id === proxyId)) {
+        throw new Error(`Proxy ${proxyId} was not found.`);
+      }
+
+      manager.saveProxyPreferences({
+        ...settings.proxy,
+        enabled: true,
+        activeProxyId: proxyId
+      });
+
+      return state();
+    },
+    disableProxy() {
+      const settings = manager.getSettings();
+      saveProxyEntries(settings.proxy.entries, false, null);
+      return state();
+    },
+    removeProxy(proxyId) {
+      const settings = manager.getSettings();
+      const entries = settings.proxy.entries.filter((entry) => entry.id !== proxyId);
+      const removedActive = settings.proxy.activeProxyId === proxyId;
+
+      tests = Object.fromEntries(Object.entries(tests).filter(([id]) => id !== proxyId));
+      saveProxyEntries(
+        entries,
+        removedActive ? false : settings.proxy.enabled,
+        removedActive ? null : settings.proxy.activeProxyId
+      );
+
+      return state();
+    }
+  });
+}

--- a/test/proxy-settings-view.test.mjs
+++ b/test/proxy-settings-view.test.mjs
@@ -1,0 +1,91 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { createProxySettingsView } from '../src/foundation/proxy-settings-view.mjs';
+
+test('proxy settings view supports add, test, enable, disable, and remove workflow', async () => {
+  const view = createProxySettingsView({
+    testProxy: async (proxy) => ({
+      reachable: proxy.host === 'proxy.example',
+      message: proxy.host === 'proxy.example' ? 'Connected' : `Could not connect with env:SECRET_VALUE`
+    })
+  });
+
+  assert.deepEqual(view.getState().list.items, []);
+  assert.equal(view.getState().route.type, 'direct');
+
+  let state = view.updateDraft({
+    id: 'primary',
+    protocol: 'mtproto',
+    host: 'proxy.example',
+    port: '443',
+    secretRef: 'env:TELETON_MTPROTO_SECRET'
+  });
+  assert.equal(state.form.valid, true);
+
+  state = view.saveDraft();
+  assert.equal(state.list.items.length, 1);
+  assert.equal(state.list.items[0].label, 'MTProto proxy.example:443');
+  assert.equal(state.list.items[0].secretConfigured, true);
+  assert.equal(state.list.items[0].secretRef, undefined);
+
+  state = await view.testProxy('primary');
+  assert.equal(state.tests.primary.status, 'success');
+  assert.equal(state.tests.primary.message, 'Connected');
+
+  state = view.enableProxy('primary');
+  assert.equal(state.route.type, 'mtproto');
+  assert.equal(state.route.proxyId, 'primary');
+
+  state = view.disableProxy();
+  assert.equal(state.route.type, 'direct');
+  assert.equal(state.list.items[0].enabled, false);
+
+  state = view.removeProxy('primary');
+  assert.deepEqual(state.list.items, []);
+  assert.equal(state.route.type, 'direct');
+});
+
+test('proxy settings view reports validation and test failures without exposing secrets', async () => {
+  const view = createProxySettingsView({
+    initialSettings: {
+      proxy: {
+        enabled: true,
+        activeProxyId: 'office',
+        entries: [
+          {
+            id: 'office',
+            protocol: 'socks5',
+            host: '10.0.0.5',
+            port: 1080,
+            usernameRef: 'keychain:proxy-user',
+            passwordRef: 'keychain:proxy-password'
+          }
+        ]
+      }
+    },
+    testProxy: async () => {
+      throw new Error('Authentication failed for keychain:proxy-password');
+    }
+  });
+
+  assert.equal(view.getState().route.type, 'socks5');
+  assert.equal(view.getState().list.items[0].usernameConfigured, true);
+  assert.equal(view.getState().list.items[0].passwordRef, undefined);
+
+  const invalid = view.updateDraft({
+    id: 'bad',
+    protocol: 'mtproto',
+    host: 'mtproxy.example',
+    port: '443',
+    secretRef: 'raw-secret'
+  });
+  assert.equal(invalid.form.valid, false);
+  assert.match(invalid.form.errors.join('\n'), /secure reference/);
+  assert.throws(() => view.saveDraft(), /secure reference/);
+
+  const tested = await view.testProxy('office');
+  assert.equal(tested.tests.office.status, 'failure');
+  assert.equal(tested.tests.office.message, 'Authentication failed for [redacted]');
+  assert.doesNotMatch(JSON.stringify(tested), /keychain:proxy-password/);
+});


### PR DESCRIPTION
## Summary
- Add a shared proxy settings view-state controller for platform UI shells.
- Cover add, edit, test, enable, disable, and remove workflows for MTProto and SOCKS5 proxies.
- Sanitize display/test snapshots so secure references are represented as configured flags instead of exposed values.
- Document the shared proxy UI boundary in README and architecture notes.

## Issue Reference
Fixes #10

## Reproduction and Verification
- Reproduced the missing workflow as new failing coverage in `test/proxy-settings-view.test.mjs` before adding the implementation.
- `npm test`
- `npm run validate:foundation`
- `npm run validate:release`
- `npm run decompose:dry-run`

## Screenshots
No screenshot is included because this foundation repository does not yet contain a renderable platform UI shell; the change provides the shared state/controller layer for those shells.

## Risks and Follow-up
- Live proxy connectivity testing remains injectable through platform adapters; this PR does not add live TDLib networking or platform-specific UI rendering.