### PR TITLE
Implement agent IPC bridge contract

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-26T13:39:34.663Z for PR creation at branch issue-12-b2ab9bfff1e3 for issue https://github.com/xlabtg/Teleton-Client/issues/12

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,6 +22,7 @@ Teleton Client is planned as a layered client where protocol, automation, wallet
 - Proxy usage statistics are local diagnostics records keyed by proxy id. They track attempts, successes, failures, latency samples, and last-used time separately from proxy configuration and never include proxy secrets or message contents.
 - Public MTProto proxy catalog use is opt-in and disabled by default. Catalog entries must include source URL/name, source verification notes, freshness timestamps, and per-entry human review metadata before they can be shipped.
 - Local Teleton Agent startup is represented by the `src/foundation/agent-runtime-supervisor.mjs` lifecycle boundary. Platform wrappers supply start, stop, health, and log hooks; the shared supervisor keeps the default runtime local and never requires cloud credentials for startup.
+- Teleton Agent UI communication is represented by the `src/foundation/agent-ipc-bridge.mjs` contract. It uses versioned IPC envelopes for request, event, response, error, and cancellation flows; UI layers receive incoming message hooks and can distinguish informational events from confirmation-required action proposals.
 - TON signing requires user confirmation and platform secure storage or wallet-provider approval.
 
 ## Local Agent Runtime
@@ -37,6 +38,12 @@ The local Teleton Agent lifecycle has four platform targets:
 
 The shared supervisor exposes `start`, `stop`, `status`, `health`, and `logs` operations. It accepts a platform adapter so each wrapper can own process management while foundation tests verify idempotent lifecycle behavior and failure state handling.
 
+## Agent IPC Bridge
+
+The shared agent IPC bridge is transport-agnostic so desktop pipes, mobile service bindings, browser workers, HTTP, or WebSocket adapters can reuse the same contract. Version 1 envelopes include an id, kind, source, target, timestamp, and object payload. Request envelopes carry an action, event envelopes carry a typed event name, responses and errors reference `replyTo`, and cancellation envelopes reference `cancelId`.
+
+UI-facing agent events are classified by confirmation behavior. Informational updates such as `agent.info`, incoming message hooks such as `agent.message.received`, and task progress events are delivered without confirmation. Action proposals such as `agent.action.proposed` are marked `requiresConfirmation: true` before dispatch so UI shells can route them to consent flows.
+
 ## Foundation Status
 
-This PR implements only the foundation layer, epic decomposition workflow, baseline TDLib adapter boundary, and local agent runtime lifecycle contract. Platform UI shells, live TDLib integration, concrete agent process packaging, and live TON operations remain tracked by the generated subtasks in `config/epic-subtasks.json`.
+This PR implements only the foundation layer, epic decomposition workflow, baseline TDLib adapter boundary, local agent runtime lifecycle contract, and agent IPC bridge contract. Platform UI shells, live TDLib integration, concrete agent process packaging, concrete IPC transports, and live TON operations remain tracked by the generated subtasks in `config/epic-subtasks.json`.

--- a/src/foundation/agent-ipc-bridge.mjs
+++ b/src/foundation/agent-ipc-bridge.mjs
@@ -1,0 +1,301 @@
+export const AGENT_IPC_VERSION = 1;
+
+export const AGENT_IPC_KINDS = Object.freeze(['request', 'event', 'response', 'error', 'cancel']);
+export const AGENT_IPC_EVENT_TYPES = Object.freeze([
+  'agent.info',
+  'agent.message.received',
+  'agent.action.proposed',
+  'agent.task.updated'
+]);
+
+const CONFIRMATION_REQUIRED_TYPES = new Set(['agent.action.proposed']);
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeId(value, fieldName) {
+  const id = String(value ?? '').trim();
+
+  if (!id) {
+    throw new Error(`${fieldName} must be a non-empty string.`);
+  }
+
+  return id;
+}
+
+function normalizeTimestamp(value) {
+  if (value === undefined) {
+    return new Date().toISOString();
+  }
+
+  const timestamp = String(value).trim();
+  if (!timestamp || Number.isNaN(Date.parse(timestamp))) {
+    throw new Error('IPC envelope timestamp must be an ISO-compatible date string.');
+  }
+
+  return timestamp;
+}
+
+function normalizePayload(value) {
+  if (value === undefined) {
+    return {};
+  }
+
+  if (!isPlainObject(value)) {
+    throw new Error('IPC envelope payload must be an object.');
+  }
+
+  return clone(value);
+}
+
+function normalizeKind(value) {
+  const kind = String(value ?? '').trim();
+
+  if (!AGENT_IPC_KINDS.includes(kind)) {
+    throw new Error(`Unsupported IPC envelope kind: ${value}`);
+  }
+
+  return kind;
+}
+
+function normalizeEventType(value) {
+  const type = String(value ?? '').trim();
+
+  if (!AGENT_IPC_EVENT_TYPES.includes(type)) {
+    throw new Error(`Unsupported IPC event type: ${value}`);
+  }
+
+  return type;
+}
+
+function validateKindSpecificShape(envelope) {
+  if (envelope.kind === 'request' && !envelope.action) {
+    throw new Error('IPC request envelopes require an action.');
+  }
+
+  if (envelope.kind === 'event') {
+    envelope.eventType = normalizeEventType(envelope.eventType);
+    envelope.requiresConfirmation = CONFIRMATION_REQUIRED_TYPES.has(envelope.eventType);
+  }
+
+  if (envelope.kind === 'response' && !envelope.replyTo) {
+    throw new Error('IPC response envelopes require replyTo.');
+  }
+
+  if (envelope.kind === 'error') {
+    if (!envelope.replyTo) {
+      throw new Error('IPC error envelopes require replyTo.');
+    }
+
+    if (!isPlainObject(envelope.error) || !envelope.error.message) {
+      throw new Error('IPC error envelopes require an error message.');
+    }
+  }
+
+  if (envelope.kind === 'cancel' && !envelope.cancelId) {
+    throw new Error('IPC cancel envelopes require cancelId.');
+  }
+}
+
+export function createAgentIpcEnvelope(input = {}) {
+  if (!isPlainObject(input)) {
+    throw new Error('IPC envelope must be an object.');
+  }
+
+  const version = input.version ?? AGENT_IPC_VERSION;
+  if (version !== AGENT_IPC_VERSION) {
+    throw new Error(`Unsupported IPC envelope version: ${version}`);
+  }
+
+  const envelope = {
+    version,
+    id: normalizeId(input.id, 'IPC envelope id'),
+    kind: normalizeKind(input.kind),
+    source: normalizeId(input.source, 'IPC envelope source'),
+    target: normalizeId(input.target, 'IPC envelope target'),
+    timestamp: normalizeTimestamp(input.timestamp),
+    payload: normalizePayload(input.payload)
+  };
+
+  if (input.action !== undefined) {
+    envelope.action = normalizeId(input.action, 'IPC request action');
+  }
+
+  if (input.eventType !== undefined) {
+    envelope.eventType = input.eventType;
+  }
+
+  if (input.replyTo !== undefined) {
+    envelope.replyTo = normalizeId(input.replyTo, 'IPC replyTo');
+  }
+
+  if (input.cancelId !== undefined) {
+    envelope.cancelId = normalizeId(input.cancelId, 'IPC cancelId');
+  }
+
+  if (input.error !== undefined) {
+    if (!isPlainObject(input.error)) {
+      throw new Error('IPC envelope error must be an object.');
+    }
+
+    envelope.error = {
+      code: String(input.error.code ?? 'agent.ipc.error'),
+      message: normalizeId(input.error.message, 'IPC error message')
+    };
+  }
+
+  validateKindSpecificShape(envelope);
+
+  return Object.freeze(envelope);
+}
+
+export function parseAgentIpcEnvelope(message) {
+  if (typeof message === 'string') {
+    try {
+      return createAgentIpcEnvelope(JSON.parse(message));
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        throw new Error(`Malformed IPC message JSON: ${error.message}`);
+      }
+
+      throw error;
+    }
+  }
+
+  return createAgentIpcEnvelope(message);
+}
+
+export function createAgentIpcBridge({ localId = 'ui', remoteId = 'agent', transport, onEvent, onRequest, onError } = {}) {
+  if (!transport || typeof transport.send !== 'function' || typeof transport.subscribe !== 'function') {
+    throw new Error('Agent IPC bridge requires a transport with send and subscribe hooks.');
+  }
+
+  const pending = new Map();
+  let sequence = 0;
+
+  function nextId(prefix) {
+    sequence += 1;
+    return `${localId}.${prefix}.${sequence}`;
+  }
+
+  async function send(envelope) {
+    await transport.send(clone(envelope));
+    return envelope;
+  }
+
+  function receive(rawMessage) {
+    let envelope;
+
+    try {
+      envelope = parseAgentIpcEnvelope(rawMessage);
+    } catch (error) {
+      onError?.(error);
+      throw error;
+    }
+
+    if (envelope.kind === 'event') {
+      onEvent?.(envelope);
+      return envelope;
+    }
+
+    if (envelope.kind === 'request') {
+      onRequest?.(envelope);
+      return envelope;
+    }
+
+    if (envelope.kind === 'response' || envelope.kind === 'error') {
+      const pendingRequest = pending.get(envelope.replyTo);
+      if (pendingRequest) {
+        pending.delete(envelope.replyTo);
+        if (envelope.kind === 'error') {
+          pendingRequest.reject(new Error(envelope.error.message));
+        } else {
+          pendingRequest.resolve(envelope);
+        }
+      }
+    }
+
+    return envelope;
+  }
+
+  const unsubscribe = transport.subscribe(receive);
+
+  return {
+    request(action, payload = {}) {
+      const envelope = createAgentIpcEnvelope({
+        id: nextId('request'),
+        kind: 'request',
+        source: localId,
+        target: remoteId,
+        action,
+        payload
+      });
+
+      const response = new Promise((resolve, reject) => {
+        pending.set(envelope.id, { resolve, reject });
+      });
+
+      return send(envelope).then(() => response);
+    },
+    emitEvent(eventType, payload = {}) {
+      return send(
+        createAgentIpcEnvelope({
+          id: nextId('event'),
+          kind: 'event',
+          source: localId,
+          target: remoteId,
+          eventType,
+          payload
+        })
+      );
+    },
+    cancel(cancelId, payload = {}) {
+      pending.delete(cancelId);
+
+      return send(
+        createAgentIpcEnvelope({
+          id: nextId('cancel'),
+          kind: 'cancel',
+          source: localId,
+          target: remoteId,
+          cancelId,
+          payload
+        })
+      );
+    },
+    receive,
+    close() {
+      pending.clear();
+      unsubscribe?.();
+    },
+    pendingRequestIds() {
+      return Array.from(pending.keys());
+    }
+  };
+}
+
+export function createMockAgentIpcTransport() {
+  const subscribers = new Set();
+  const sent = [];
+
+  return {
+    sent,
+    async send(message) {
+      sent.push(clone(message));
+    },
+    subscribe(handler) {
+      subscribers.add(handler);
+      return () => subscribers.delete(handler);
+    },
+    deliver(message) {
+      for (const handler of subscribers) {
+        handler(message);
+      }
+    }
+  };
+}

--- a/test/agent-ipc-bridge.test.mjs
+++ b/test/agent-ipc-bridge.test.mjs
@@ -1,0 +1,131 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  AGENT_IPC_VERSION,
+  createAgentIpcBridge,
+  createAgentIpcEnvelope,
+  createMockAgentIpcTransport,
+  parseAgentIpcEnvelope
+} from '../src/foundation/agent-ipc-bridge.mjs';
+
+test('agent IPC envelopes are versioned and classify confirmation-required events', () => {
+  const info = createAgentIpcEnvelope({
+    id: 'event-1',
+    kind: 'event',
+    source: 'agent',
+    target: 'ui',
+    eventType: 'agent.info',
+    payload: { message: 'synced' },
+    timestamp: '2026-04-26T00:00:00.000Z'
+  });
+
+  assert.equal(info.version, AGENT_IPC_VERSION);
+  assert.equal(info.requiresConfirmation, false);
+
+  const proposal = createAgentIpcEnvelope({
+    id: 'event-2',
+    kind: 'event',
+    source: 'agent',
+    target: 'ui',
+    eventType: 'agent.action.proposed',
+    payload: { action: 'sendMessage', chatId: 42 },
+    timestamp: '2026-04-26T00:00:01.000Z'
+  });
+
+  assert.equal(proposal.requiresConfirmation, true);
+});
+
+test('agent IPC bridge supports request, response, event, and cancellation flows', async () => {
+  const events = [];
+  const requests = [];
+  const transport = createMockAgentIpcTransport();
+  const bridge = createAgentIpcBridge({
+    localId: 'ui',
+    remoteId: 'agent',
+    transport,
+    onEvent: (event) => events.push(event),
+    onRequest: (request) => requests.push(request)
+  });
+
+  const responsePromise = bridge.request('agent.task.create', { text: 'summarize chat' });
+  assert.deepEqual(bridge.pendingRequestIds(), ['ui.request.1']);
+  assert.equal(transport.sent[0].kind, 'request');
+  assert.equal(transport.sent[0].action, 'agent.task.create');
+
+  transport.deliver({
+    id: 'agent.response.1',
+    kind: 'response',
+    source: 'agent',
+    target: 'ui',
+    replyTo: 'ui.request.1',
+    payload: { taskId: 'task-1' }
+  });
+
+  const response = await responsePromise;
+  assert.equal(response.payload.taskId, 'task-1');
+  assert.deepEqual(bridge.pendingRequestIds(), []);
+
+  transport.deliver({
+    id: 'agent.event.1',
+    kind: 'event',
+    source: 'agent',
+    target: 'ui',
+    eventType: 'agent.action.proposed',
+    payload: { action: 'sendMessage' }
+  });
+  assert.equal(events[0].requiresConfirmation, true);
+
+  transport.deliver({
+    id: 'agent.request.1',
+    kind: 'request',
+    source: 'agent',
+    target: 'ui',
+    action: 'ui.message.hook',
+    payload: { chatId: 7 }
+  });
+  assert.equal(requests[0].action, 'ui.message.hook');
+
+  await bridge.cancel('missing-request');
+  assert.equal(transport.sent.at(-1).kind, 'cancel');
+  assert.equal(transport.sent.at(-1).cancelId, 'missing-request');
+
+  bridge.close();
+});
+
+test('agent IPC bridge rejects malformed messages before dispatch', () => {
+  assert.throws(() => parseAgentIpcEnvelope('{'), /Malformed IPC message JSON/);
+  assert.throws(
+    () =>
+      parseAgentIpcEnvelope({
+        id: 'bad-1',
+        kind: 'event',
+        source: 'agent',
+        target: 'ui',
+        eventType: 'agent.unknown'
+      }),
+    /Unsupported IPC event type/
+  );
+  assert.throws(
+    () =>
+      parseAgentIpcEnvelope({
+        id: 'bad-2',
+        kind: 'request',
+        source: 'ui',
+        target: 'agent'
+      }),
+    /request envelopes require an action/
+  );
+  assert.throws(
+    () =>
+      parseAgentIpcEnvelope({
+        version: 99,
+        id: 'bad-3',
+        kind: 'event',
+        source: 'agent',
+        target: 'ui',
+        eventType: 'agent.info'
+      }),
+    /Unsupported IPC envelope version/
+  );
+});

--- a/test/foundation.test.mjs
+++ b/test/foundation.test.mjs
@@ -174,6 +174,30 @@ test('local agent runtime lifecycle boundary is documented and credential-free b
   }
 });
 
+test('agent IPC bridge exposes versioned envelopes and confirmation-aware UI events', async () => {
+  const { AGENT_IPC_EVENT_TYPES, AGENT_IPC_KINDS, AGENT_IPC_VERSION, createAgentIpcEnvelope } = await import(
+    '../src/foundation/agent-ipc-bridge.mjs'
+  );
+  const architecture = await readFile(pathFor('docs/architecture.md'), 'utf8');
+
+  assert.equal(AGENT_IPC_VERSION, 1);
+  assert.deepEqual(AGENT_IPC_KINDS, ['request', 'event', 'response', 'error', 'cancel']);
+  assert.ok(AGENT_IPC_EVENT_TYPES.includes('agent.message.received'));
+  assert.ok(AGENT_IPC_EVENT_TYPES.includes('agent.action.proposed'));
+  assert.match(architecture, /versioned IPC bridge/i);
+  assert.match(architecture, /confirmation-required/i);
+
+  const proposal = createAgentIpcEnvelope({
+    id: 'proposal-1',
+    kind: 'event',
+    source: 'agent',
+    target: 'ui',
+    eventType: 'agent.action.proposed'
+  });
+
+  assert.equal(proposal.requiresConfirmation, true);
+});
+
 test('proxy settings model covers supported proxy types without hardcoded secrets', async () => {
   const { PROXY_PROTOCOLS, validateProxyConfig } = await import('../src/foundation/proxy-settings.mjs');
   const { PROXY_ROUTE_TYPES, createProxyManager } = await import('../src/foundation/proxy-manager.mjs');


### PR DESCRIPTION
## Summary
- Add a transport-agnostic Teleton Agent IPC bridge contract with versioned envelopes.
- Support request, response, event, error, and cancellation flows through pluggable transports.
- Classify UI-facing agent events so informational updates and confirmation-required action proposals are distinguishable.
- Document the IPC bridge boundary in the architecture notes.

## Tests
- npm test
- npm run validate:foundation
- npm run validate:release
- npm run decompose:dry-run

## Notes
- This is the shared foundation contract only. Concrete platform transports such as desktop pipes, mobile service bindings, HTTP, or WebSocket adapters remain follow-up platform work.

Fixes #12