### PR TITLE
[022] Build agent settings screen state

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-26T13:39:34.663Z for PR creation at branch issue-12-b2ab9bfff1e3 for issue https://github.com/xlabtg/Teleton-Client/issues/12
+# Updated: 2026-04-26T13:43:48.646Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-26T13:39:34.663Z for PR creation at branch issue-12-b2ab9bfff1e3 for issue https://github.com/xlabtg/Teleton-Client/issues/12

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-26T13:39:34.663Z for PR creation at branch issue-12-b2ab9bfff1e3 for issue https://github.com/xlabtg/Teleton-Client/issues/12
-# Updated: 2026-04-26T13:43:48.646Z

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This repository is in the foundation phase. The current implementation establish
 - GitHub issue and pull request templates for reproducible, secret-free contributions.
 - Dry-run and idempotent GitHub issue creation script for decomposing issue `#1`.
 - Shared cross-platform settings model for language, theme, notifications, agent mode, proxy, and secure references.
+- Shared agent settings view state for off, local, cloud, and hybrid modes, model preferences, privacy prompts, approval preferences, and autonomous action limits.
 - ProxyManager route selection for direct, MTProto, and SOCKS5 connectivity using saved preferences, health inputs, latency ranking, and failure cooldowns.
 - Shared proxy settings view state for add, test, enable, disable, edit, remove, reset statistics, and export diagnostics workflows without exposing secure references.
 - Local proxy usage statistics for attempts, successes, failures, latency, and last-used time, stored separately from proxy secrets.
@@ -47,7 +48,7 @@ The project is intended to evolve through these layers:
 4. TON blockchain integrations for wallet, transfers, swaps, NFTs, staking, and DNS.
 5. Security and privacy controls for credentials, user consent, and auditability.
 
-See `docs/architecture.md`, `docs/backlog.md`, `docs/tdlib-adapter.md`, and `docs/release-strategy.md` for the current foundation plan. The local agent runtime section in `docs/architecture.md` records supported runtime directions and packaging gaps for Android, iOS, desktop, and web wrappers.
+See `docs/architecture.md`, `docs/backlog.md`, `docs/tdlib-adapter.md`, and `docs/release-strategy.md` for the current foundation plan. The agent settings and local runtime sections in `docs/architecture.md` record the shared settings UI contract, supported runtime directions, and packaging gaps for Android, iOS, desktop, and web wrappers.
 
 ## Contribution Templates
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,6 +17,7 @@ Teleton Client is planned as a layered client where protocol, automation, wallet
 - TDLib credentials must be supplied at runtime and never committed.
 - TDLib callers use the shared `authenticate`, `getChatList`, `sendMessage`, and `subscribeUpdates` adapter contract so Android, iOS, desktop, and web-compatible bridges expose the same boundary.
 - Agent mode defaults to `off`; cloud and hybrid modes require explicit activation.
+- Agent settings UI shells use shared view state for mode options, model provider preferences, privacy impact prompts, approval preferences, and autonomous action limits. Cloud and hybrid activation stays pending until the user confirms the privacy impact summary.
 - Proxy secrets are represented as secure references such as `env:NAME`, `keychain:name`, or `keystore:name`.
 - Proxy settings UI shells use shared view state for list items, edit forms, test status, auto-switch preferences, and active route metadata. Display snapshots expose only configured flags for secrets, while settings persistence keeps secure references for platform storage resolution.
 - Proxy usage statistics are local diagnostics records keyed by proxy id. They track attempts, successes, failures, latency samples, and last-used time separately from proxy configuration and never include proxy secrets or message contents.
@@ -43,6 +44,12 @@ The shared supervisor exposes `start`, `stop`, `status`, `health`, and `logs` op
 The shared agent IPC bridge is transport-agnostic so desktop pipes, mobile service bindings, browser workers, HTTP, or WebSocket adapters can reuse the same contract. Version 1 envelopes include an id, kind, source, target, timestamp, and object payload. Request envelopes carry an action, event envelopes carry a typed event name, responses and errors reference `replyTo`, and cancellation envelopes reference `cancelId`.
 
 UI-facing agent events are classified by confirmation behavior. Informational updates such as `agent.info`, incoming message hooks such as `agent.message.received`, and task progress events are delivered without confirmation. Action proposals such as `agent.action.proposed` are marked `requiresConfirmation: true` before dispatch so UI shells can route them to consent flows.
+
+## Agent Settings UI
+
+The shared agent settings view state is implemented in `src/foundation/agent-settings-view.mjs`. It exposes the canonical `off`, `local`, `cloud`, and `hybrid` mode controls from the settings model, keeps the default mode off, and blocks cloud-capable mode changes behind an explicit privacy impact confirmation step before enabling cloud processing consent.
+
+The view also carries model provider/model id preferences, confirmation requirements, and the per-hour autonomous action limit. Platform UI shells can render this state directly while persisting only the validated shared agent settings payload.
 
 ## Foundation Status
 

--- a/src/foundation/agent-settings-view.mjs
+++ b/src/foundation/agent-settings-view.mjs
@@ -1,0 +1,213 @@
+import { AGENT_MODES, createAgentSettings, normalizeAgentMode, validateAgentSettings } from './agent-settings.mjs';
+
+export const AGENT_PRIVACY_IMPACT_MODES = Object.freeze(['cloud', 'hybrid']);
+
+export const AGENT_MODEL_PROVIDERS = Object.freeze(['local', 'openai', 'teleton-cloud', 'custom']);
+
+const MODE_COPY = Object.freeze({
+  off: Object.freeze({
+    label: 'Off',
+    description: 'Automation is disabled.'
+  }),
+  local: Object.freeze({
+    label: 'Local',
+    description: 'Runs the agent on this device or through a local runtime bridge.'
+  }),
+  cloud: Object.freeze({
+    label: 'Cloud',
+    description: 'Uses a remote model provider after explicit consent.'
+  }),
+  hybrid: Object.freeze({
+    label: 'Hybrid',
+    description: 'Uses local automation first and can escalate selected work to a remote provider after consent.'
+  })
+});
+
+const PRIVACY_IMPACT = Object.freeze({
+  cloud: Object.freeze({
+    mode: 'cloud',
+    summary: 'Cloud processing can send selected message context, prompts, and action metadata to a remote model provider.',
+    dataShared: Object.freeze(['Selected message context', 'Agent prompts', 'Action metadata', 'Model telemetry']),
+    localDataRetained: Object.freeze(['Local agent memory', 'Secure references and credentials']),
+    requiresConsent: true
+  }),
+  hybrid: Object.freeze({
+    mode: 'hybrid',
+    summary: 'Hybrid mode keeps local automation available but can send selected work to cloud processing when needed.',
+    dataShared: Object.freeze(['Selected message context', 'Agent prompts', 'Cloud fallback metadata']),
+    localDataRetained: Object.freeze(['Local agent memory', 'Secure references and credentials']),
+    requiresConsent: true
+  })
+});
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function modeOptions() {
+  return AGENT_MODES.map((mode) => ({
+    id: mode,
+    ...MODE_COPY[mode],
+    requiresPrivacyConfirmation: AGENT_PRIVACY_IMPACT_MODES.includes(mode)
+  }));
+}
+
+function normalizeModelPreference(value) {
+  if (value === null) {
+    return null;
+  }
+
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Agent model preference must be null or an object.');
+  }
+
+  const provider = String(value.provider ?? '').trim();
+  const modelId = String(value.modelId ?? '').trim();
+
+  if (!AGENT_MODEL_PROVIDERS.includes(provider)) {
+    throw new Error(`Agent model provider must be one of: ${AGENT_MODEL_PROVIDERS.join(', ')}.`);
+  }
+
+  if (!modelId) {
+    throw new Error('Agent model id is required.');
+  }
+
+  const model = {
+    provider,
+    modelId
+  };
+
+  const displayName = String(value.displayName ?? '').trim();
+  if (displayName) {
+    model.displayName = displayName;
+  }
+
+  return model;
+}
+
+function activationState(pendingMode = null) {
+  const pending = pendingMode !== null;
+
+  return {
+    pending,
+    requestedMode: pendingMode,
+    requiresPrivacyConfirmation: pending,
+    privacyImpact: pending ? clone(PRIVACY_IMPACT[pendingMode]) : null
+  };
+}
+
+function normalizeActionLimit(value, mode) {
+  const limit = Number(value);
+
+  if (!Number.isInteger(limit)) {
+    throw new Error('Agent action limit must be an integer.');
+  }
+
+  if (limit < 0) {
+    throw new Error('Agent action limit cannot be negative.');
+  }
+
+  return mode === 'off' ? 0 : limit;
+}
+
+export function createAgentSettingsView(options = {}) {
+  let settings = createAgentSettings(options.initialSettings);
+  let pendingMode = null;
+
+  function save(nextSettings) {
+    const validation = validateAgentSettings(nextSettings);
+
+    if (!validation.valid) {
+      throw new Error(validation.errors.join(' '));
+    }
+
+    settings = validation.settings;
+    return state();
+  }
+
+  function state() {
+    return {
+      mode: {
+        selected: settings.mode,
+        options: modeOptions()
+      },
+      model: {
+        providers: AGENT_MODEL_PROVIDERS.map((provider) => ({ id: provider })),
+        selected: clone(settings.model)
+      },
+      privacy: {
+        allowCloudProcessing: settings.allowCloudProcessing,
+        impacts: clone(PRIVACY_IMPACT)
+      },
+      approvals: {
+        requireConfirmation: settings.requireConfirmation
+      },
+      actionLimits: {
+        maxAutonomousActionsPerHour: settings.maxAutonomousActionsPerHour,
+        disabled: settings.mode === 'off'
+      },
+      activation: activationState(pendingMode),
+      settings: clone(settings)
+    };
+  }
+
+  return Object.freeze({
+    getState() {
+      return state();
+    },
+    selectMode(value) {
+      const mode = normalizeAgentMode(value);
+
+      if (AGENT_PRIVACY_IMPACT_MODES.includes(mode)) {
+        pendingMode = mode;
+        return state();
+      }
+
+      pendingMode = null;
+      return save({
+        ...settings,
+        mode,
+        allowCloudProcessing: false,
+        maxAutonomousActionsPerHour: mode === 'off' ? 0 : settings.maxAutonomousActionsPerHour
+      });
+    },
+    confirmPrivacyImpact() {
+      if (pendingMode === null) {
+        return state();
+      }
+
+      const mode = pendingMode;
+      pendingMode = null;
+      return save({
+        ...settings,
+        mode,
+        allowCloudProcessing: true
+      });
+    },
+    cancelPrivacyImpact() {
+      pendingMode = null;
+      return state();
+    },
+    setModelPreference(value) {
+      return save({
+        ...settings,
+        model: normalizeModelPreference(value)
+      });
+    },
+    setRequireConfirmation(value) {
+      return save({
+        ...settings,
+        requireConfirmation: value === true
+      });
+    },
+    setActionLimit(value) {
+      return save({
+        ...settings,
+        maxAutonomousActionsPerHour: normalizeActionLimit(value, settings.mode)
+      });
+    },
+    exportSettings() {
+      return clone(settings);
+    }
+  });
+}

--- a/test/agent-settings-view.test.mjs
+++ b/test/agent-settings-view.test.mjs
@@ -1,0 +1,76 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  AGENT_PRIVACY_IMPACT_MODES,
+  createAgentSettingsView
+} from '../src/foundation/agent-settings-view.mjs';
+
+test('agent settings view exposes mode, model, privacy, approval, and rate limit controls', () => {
+  const view = createAgentSettingsView();
+
+  assert.deepEqual(view.getState().mode.options.map((option) => option.id), ['off', 'local', 'cloud', 'hybrid']);
+  assert.equal(view.getState().settings.mode, 'off');
+  assert.equal(view.getState().settings.allowCloudProcessing, false);
+  assert.equal(view.getState().settings.maxAutonomousActionsPerHour, 0);
+  assert.equal(view.getState().activation.pending, false);
+
+  let state = view.setModelPreference({
+    provider: 'local',
+    modelId: 'teleton-local-small',
+    displayName: 'Teleton Local Small'
+  });
+  assert.deepEqual(state.settings.model, {
+    provider: 'local',
+    modelId: 'teleton-local-small',
+    displayName: 'Teleton Local Small'
+  });
+
+  state = view.setRequireConfirmation(false);
+  assert.equal(state.settings.requireConfirmation, false);
+
+  state = view.selectMode('local');
+  assert.equal(state.settings.mode, 'local');
+
+  state = view.setActionLimit(12);
+  assert.equal(state.settings.maxAutonomousActionsPerHour, 12);
+});
+
+test('agent settings view requires privacy impact confirmation before cloud or hybrid activation', () => {
+  const view = createAgentSettingsView();
+
+  let state = view.selectMode('cloud');
+  assert.equal(state.settings.mode, 'off');
+  assert.equal(state.activation.pending, true);
+  assert.equal(state.activation.requestedMode, 'cloud');
+  assert.equal(state.activation.requiresPrivacyConfirmation, true);
+  assert.match(state.activation.privacyImpact.summary, /cloud processing/i);
+
+  state = view.confirmPrivacyImpact();
+  assert.equal(state.settings.mode, 'cloud');
+  assert.equal(state.settings.allowCloudProcessing, true);
+  assert.equal(state.activation.pending, false);
+
+  state = view.selectMode('off');
+  assert.equal(state.settings.mode, 'off');
+  assert.equal(state.settings.allowCloudProcessing, false);
+  assert.equal(state.settings.maxAutonomousActionsPerHour, 0);
+
+  state = view.selectMode('hybrid');
+  assert.equal(state.settings.mode, 'off');
+  assert.equal(state.activation.requestedMode, 'hybrid');
+
+  state = view.cancelPrivacyImpact();
+  assert.equal(state.settings.mode, 'off');
+  assert.equal(state.activation.pending, false);
+});
+
+test('agent settings view activates local mode without cloud privacy consent', () => {
+  const view = createAgentSettingsView();
+
+  const state = view.selectMode('local');
+  assert.equal(state.settings.mode, 'local');
+  assert.equal(state.settings.allowCloudProcessing, false);
+  assert.equal(state.activation.pending, false);
+  assert.deepEqual(AGENT_PRIVACY_IMPACT_MODES, ['cloud', 'hybrid']);
+});

--- a/test/foundation.test.mjs
+++ b/test/foundation.test.mjs
@@ -156,6 +156,25 @@ test('agent autonomy modes match the epic acceptance criteria', async () => {
   assert.equal(normalizeAgentMode('Локально'), 'local');
 });
 
+test('agent settings view requires consent before cloud-capable modes', async () => {
+  const { AGENT_PRIVACY_IMPACT_MODES, createAgentSettingsView } = await import(
+    '../src/foundation/agent-settings-view.mjs'
+  );
+
+  const view = createAgentSettingsView();
+  assert.equal(view.getState().settings.mode, 'off');
+  assert.deepEqual(AGENT_PRIVACY_IMPACT_MODES, ['cloud', 'hybrid']);
+
+  const pending = view.selectMode('hybrid');
+  assert.equal(pending.settings.mode, 'off');
+  assert.equal(pending.activation.requiresPrivacyConfirmation, true);
+  assert.match(pending.activation.privacyImpact.summary, /cloud processing/i);
+
+  const confirmed = view.confirmPrivacyImpact();
+  assert.equal(confirmed.settings.mode, 'hybrid');
+  assert.equal(confirmed.settings.allowCloudProcessing, true);
+});
+
 test('local agent runtime lifecycle boundary is documented and credential-free by default', async () => {
   const { AGENT_RUNTIME_PLATFORMS, describeAgentRuntimeSupport } = await import(
     '../src/foundation/agent-runtime-supervisor.mjs'


### PR DESCRIPTION
## Summary
- Adds a shared agent settings view model for off, local, cloud, and hybrid mode controls.
- Exposes model provider/model id preferences, approval preference state, privacy impact metadata, and autonomous action limits.
- Keeps automation disabled by default and requires explicit privacy impact confirmation before activating cloud or hybrid mode.
- Documents the shared agent settings UI contract in README and architecture docs.

## Tests
- npm test
- npm run validate:foundation
- npm run validate:release
- npm run decompose:dry-run

Fixes #13