### PR TITLE
Encrypt local agent memory through secure storage keys

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-26T13:39:34.663Z for PR creation at branch issue-12-b2ab9bfff1e3 for issue https://github.com/xlabtg/Teleton-Client/issues/12
+# Updated: 2026-04-26T13:57:20.603Z

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repository is in the foundation phase. The current implementation establish
 - Optional public MTProto proxy catalog metadata model that stays disabled by default and requires source freshness plus human review metadata before release.
 - Baseline TDLib client adapter contract with mock-backed tests.
 - Local Teleton Agent runtime supervisor contract with mock lifecycle tests for start, stop, health, and logs.
+- Local Teleton Agent memory encryption contract using platform secure storage key providers, AES-256-GCM payloads, migration, missing-key, locked-store, and key-rotation tests.
 - CI workflow for foundation checks.
 - Documented semantic version source of truth and release metadata validation.
 - Required project documents: `README.md`, `PRIVACY.md`, `LICENSE`, and `BUILD-GUIDE.md`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,6 +24,7 @@ Teleton Client is planned as a layered client where protocol, automation, wallet
 - Public MTProto proxy catalog use is opt-in and disabled by default. Catalog entries must include source URL/name, source verification notes, freshness timestamps, and per-entry human review metadata before they can be shipped.
 - Local Teleton Agent startup is represented by the `src/foundation/agent-runtime-supervisor.mjs` lifecycle boundary. Platform wrappers supply start, stop, health, and log hooks; the shared supervisor keeps the default runtime local and never requires cloud credentials for startup.
 - Teleton Agent UI communication is represented by the `src/foundation/agent-ipc-bridge.mjs` contract. It uses versioned IPC envelopes for request, event, response, error, and cancellation flows; UI layers receive incoming message hooks and can distinguish informational events from confirmation-required action proposals.
+- Local Teleton Agent memory is represented by the `src/foundation/agent-memory-store.mjs` contract. It encrypts memory snapshots, vector index payloads, and local credential references with AES-256-GCM while platform wrappers keep the raw data key in OS secure storage providers such as Keychain or Keystore.
 - TON signing requires user confirmation and platform secure storage or wallet-provider approval.
 
 ## Local Agent Runtime
@@ -45,6 +46,12 @@ The shared agent IPC bridge is transport-agnostic so desktop pipes, mobile servi
 
 UI-facing agent events are classified by confirmation behavior. Informational updates such as `agent.info`, incoming message hooks such as `agent.message.received`, and task progress events are delivered without confirmation. Action proposals such as `agent.action.proposed` are marked `requiresConfirmation: true` before dispatch so UI shells can route them to consent flows.
 
+## Agent Memory Encryption
+
+Agent memory encryption is enabled by default in the shared settings model through `security.encryptAgentMemory`. The foundation layer refuses settings that disable it and accepts only secure references for custom `security.agentMemoryKeyRef` values.
+
+Platform wrappers supply a secure storage provider with `get` and `set` hooks. The shared memory store creates or reads the platform data key, encrypts JSON-serializable memory payloads with AES-256-GCM, stores only ciphertext plus nonce/authentication metadata in local files, and resolves the key only during unlock, migration, or rotation flows. Missing keys and locked secure storage states fail closed so plaintext memory is not returned.
+
 ## Agent Settings UI
 
 The shared agent settings view state is implemented in `src/foundation/agent-settings-view.mjs`. It exposes the canonical `off`, `local`, `cloud`, and `hybrid` mode controls from the settings model, keeps the default mode off, and blocks cloud-capable mode changes behind an explicit privacy impact confirmation step before enabling cloud processing consent.
@@ -53,4 +60,4 @@ The view also carries model provider/model id preferences, confirmation requirem
 
 ## Foundation Status
 
-This PR implements only the foundation layer, epic decomposition workflow, baseline TDLib adapter boundary, local agent runtime lifecycle contract, and agent IPC bridge contract. Platform UI shells, live TDLib integration, concrete agent process packaging, concrete IPC transports, and live TON operations remain tracked by the generated subtasks in `config/epic-subtasks.json`.
+This PR implements only the foundation layer, epic decomposition workflow, baseline TDLib adapter boundary, local agent runtime lifecycle contract, agent IPC bridge contract, and local agent memory encryption contract. Platform UI shells, live TDLib integration, concrete agent process packaging, concrete IPC transports, concrete secure storage bindings, and live TON operations remain tracked by the generated subtasks in `config/epic-subtasks.json`.

--- a/src/foundation/agent-memory-store.mjs
+++ b/src/foundation/agent-memory-store.mjs
@@ -1,0 +1,217 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+
+export const AGENT_MEMORY_SCHEMA_VERSION = 1;
+export const AGENT_MEMORY_ENCRYPTION_ALGORITHM = 'AES-256-GCM';
+export const AGENT_MEMORY_KEY_PURPOSE = 'teleton.agentMemory';
+export const AGENT_MEMORY_PLATFORMS = Object.freeze(['android', 'ios', 'desktop', 'web']);
+
+const KEY_BYTES = 32;
+const IV_BYTES = 12;
+const AUTH_TAG_BYTES = 16;
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function normalizePlatform(value) {
+  const platform = String(value ?? '').trim().toLowerCase();
+
+  if (!AGENT_MEMORY_PLATFORMS.includes(platform)) {
+    throw new Error(`Unsupported agent memory platform: ${value}`);
+  }
+
+  return platform;
+}
+
+function defaultKeyRef(platform) {
+  const prefix = platform === 'ios' || platform === 'desktop' ? 'keychain' : 'keystore';
+  return `${prefix}:${AGENT_MEMORY_KEY_PURPOSE}.${platform}.v1`;
+}
+
+function encode(value) {
+  return Buffer.from(value).toString('base64url');
+}
+
+function decode(value, label) {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`${label} must be a non-empty base64url string.`);
+  }
+
+  return Buffer.from(value, 'base64url');
+}
+
+function assertSecureStorage(secureStorage) {
+  if (!secureStorage || typeof secureStorage.get !== 'function' || typeof secureStorage.set !== 'function') {
+    throw new Error('Agent memory encryption requires secure storage with get and set hooks.');
+  }
+}
+
+function normalizeKey(key, keyRef) {
+  const keyBuffer = Buffer.isBuffer(key) ? key : Buffer.from(String(key ?? ''), 'base64url');
+
+  if (keyBuffer.length !== KEY_BYTES) {
+    throw new Error(`Secure storage key ${keyRef} must be ${KEY_BYTES} bytes.`);
+  }
+
+  return keyBuffer;
+}
+
+async function readKey(secureStorage, keyRef) {
+  const key = await secureStorage.get(keyRef);
+
+  if (key === undefined || key === null) {
+    throw new Error(`Missing secure storage key: ${keyRef}.`);
+  }
+
+  return normalizeKey(key, keyRef);
+}
+
+async function getOrCreateKey(secureStorage, keyRef) {
+  const existing = await secureStorage.get(keyRef);
+
+  if (existing !== undefined && existing !== null) {
+    return normalizeKey(existing, keyRef);
+  }
+
+  const key = randomBytes(KEY_BYTES);
+  await secureStorage.set(keyRef, key);
+  return key;
+}
+
+function isEncryptedAgentMemoryPayload(payload) {
+  return (
+    payload !== null &&
+    typeof payload === 'object' &&
+    payload.schemaVersion === AGENT_MEMORY_SCHEMA_VERSION &&
+    payload.encryption?.algorithm === AGENT_MEMORY_ENCRYPTION_ALGORITHM &&
+    typeof payload.ciphertext === 'string'
+  );
+}
+
+export function createMockSecureStorageProvider(options = {}) {
+  const calls = [];
+  const values = new Map(Object.entries(options.values ?? {}));
+
+  function assertUnlocked() {
+    if (options.locked) {
+      throw new Error('Platform secure storage is locked.');
+    }
+  }
+
+  return {
+    calls,
+    async get(keyRef) {
+      calls.push({ operation: 'get', keyRef });
+      assertUnlocked();
+      return values.get(keyRef) ?? null;
+    },
+    async set(keyRef, value) {
+      calls.push({ operation: 'set', keyRef });
+      assertUnlocked();
+      values.set(keyRef, Buffer.from(value));
+    },
+    async delete(keyRef) {
+      calls.push({ operation: 'delete', keyRef });
+      assertUnlocked();
+      values.delete(keyRef);
+    },
+    snapshot() {
+      return new Map(values);
+    }
+  };
+}
+
+export async function encryptAgentMemoryPayload(memory, { platform, secureStorage, keyRef } = {}) {
+  assertSecureStorage(secureStorage);
+
+  const normalizedPlatform = normalizePlatform(platform);
+  const resolvedKeyRef = keyRef ?? defaultKeyRef(normalizedPlatform);
+  const key = await getOrCreateKey(secureStorage, resolvedKeyRef);
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv('aes-256-gcm', key, iv, { authTagLength: AUTH_TAG_BYTES });
+  const plaintext = Buffer.from(JSON.stringify(memory), 'utf8');
+  const ciphertext = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+  const authTag = cipher.getAuthTag();
+
+  return {
+    schemaVersion: AGENT_MEMORY_SCHEMA_VERSION,
+    encryption: {
+      algorithm: AGENT_MEMORY_ENCRYPTION_ALGORITHM,
+      keyRef: resolvedKeyRef,
+      purpose: AGENT_MEMORY_KEY_PURPOSE,
+      platform: normalizedPlatform,
+      iv: encode(iv),
+      authTag: encode(authTag)
+    },
+    ciphertext: encode(ciphertext)
+  };
+}
+
+export async function decryptAgentMemoryPayload(payload, { secureStorage } = {}) {
+  assertSecureStorage(secureStorage);
+
+  if (!isEncryptedAgentMemoryPayload(payload)) {
+    throw new Error('Agent memory payload is not encrypted.');
+  }
+
+  const key = await readKey(secureStorage, payload.encryption.keyRef);
+  const decipher = createDecipheriv('aes-256-gcm', key, decode(payload.encryption.iv, 'Agent memory iv'), {
+    authTagLength: AUTH_TAG_BYTES
+  });
+  decipher.setAuthTag(decode(payload.encryption.authTag, 'Agent memory authTag'));
+  const plaintext = Buffer.concat([decipher.update(decode(payload.ciphertext, 'Agent memory ciphertext')), decipher.final()]);
+
+  return JSON.parse(plaintext.toString('utf8'));
+}
+
+export async function migratePlainAgentMemory(payload, { platform, secureStorage, keyRef } = {}) {
+  if (isEncryptedAgentMemoryPayload(payload)) {
+    return {
+      migrated: false,
+      payload: clone(payload)
+    };
+  }
+
+  return {
+    migrated: true,
+    payload: await encryptAgentMemoryPayload(payload, { platform, secureStorage, keyRef })
+  };
+}
+
+export function createAgentMemoryStore({ platform, secureStorage, keyRef } = {}) {
+  assertSecureStorage(secureStorage);
+  const normalizedPlatform = normalizePlatform(platform);
+  const resolvedKeyRef = keyRef ?? defaultKeyRef(normalizedPlatform);
+
+  return {
+    async encrypt(memory) {
+      return encryptAgentMemoryPayload(memory, {
+        platform: normalizedPlatform,
+        secureStorage,
+        keyRef: resolvedKeyRef
+      });
+    },
+    async decrypt(payload) {
+      return decryptAgentMemoryPayload(payload, { secureStorage });
+    },
+    async migrate(payload) {
+      return migratePlainAgentMemory(payload, {
+        platform: normalizedPlatform,
+        secureStorage,
+        keyRef: resolvedKeyRef
+      });
+    },
+    async rotateKey(payload, { keyRef: nextKeyRef } = {}) {
+      const memory = await decryptAgentMemoryPayload(payload, { secureStorage });
+
+      return encryptAgentMemoryPayload(memory, {
+        platform: normalizedPlatform,
+        secureStorage,
+        keyRef: nextKeyRef ?? resolvedKeyRef
+      });
+    },
+    keyRef() {
+      return resolvedKeyRef;
+    }
+  };
+}

--- a/src/foundation/settings-model.mjs
+++ b/src/foundation/settings-model.mjs
@@ -45,6 +45,8 @@ export const DEFAULT_TELETON_SETTINGS = deepFreeze({
     biometricUnlock: false,
     lockAfterMinutes: 0,
     redactSensitiveNotifications: true,
+    encryptAgentMemory: true,
+    agentMemoryKeyRef: null,
     secretRefs: {}
   }
 });
@@ -387,12 +389,15 @@ function normalizeSecurity(value, errors) {
     lockAfterMinutes: securityInput.lockAfterMinutes ?? DEFAULT_TELETON_SETTINGS.security.lockAfterMinutes,
     redactSensitiveNotifications:
       securityInput.redactSensitiveNotifications ?? DEFAULT_TELETON_SETTINGS.security.redactSensitiveNotifications,
+    encryptAgentMemory: securityInput.encryptAgentMemory ?? DEFAULT_TELETON_SETTINGS.security.encryptAgentMemory,
+    agentMemoryKeyRef: securityInput.agentMemoryKeyRef ?? DEFAULT_TELETON_SETTINGS.security.agentMemoryKeyRef,
     secretRefs
   };
 
   booleanError(security.requireDeviceLock, 'Security requireDeviceLock', errors);
   booleanError(security.biometricUnlock, 'Security biometricUnlock', errors);
   booleanError(security.redactSensitiveNotifications, 'Security redactSensitiveNotifications', errors);
+  booleanError(security.encryptAgentMemory, 'Security encryptAgentMemory', errors);
 
   if (!Number.isInteger(security.lockAfterMinutes) || security.lockAfterMinutes < 0 || security.lockAfterMinutes > 1440) {
     errors.push('Security lockAfterMinutes must be an integer between 0 and 1440.');
@@ -400,6 +405,14 @@ function normalizeSecurity(value, errors) {
 
   if (security.biometricUnlock === true && security.requireDeviceLock !== true) {
     errors.push('Biometric unlock requires device lock to be enabled.');
+  }
+
+  if (security.encryptAgentMemory !== true) {
+    errors.push('Agent memory encryption must remain enabled.');
+  }
+
+  if (security.agentMemoryKeyRef !== null && !isSecureReference(security.agentMemoryKeyRef)) {
+    errors.push('Security agentMemoryKeyRef must be null or a secure reference such as keychain:name or keystore:name.');
   }
 
   return security;

--- a/test/agent-memory-store.test.mjs
+++ b/test/agent-memory-store.test.mjs
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  AGENT_MEMORY_KEY_PURPOSE,
+  createAgentMemoryStore,
+  createMockSecureStorageProvider,
+  decryptAgentMemoryPayload,
+  encryptAgentMemoryPayload,
+  migratePlainAgentMemory
+} from '../src/foundation/agent-memory-store.mjs';
+
+const sampleMemory = Object.freeze({
+  facts: [{ id: 'f1', text: 'User prefers local agent mode.' }],
+  vectorIndexes: [{ id: 'chat-1', dimensions: 3, values: [0.1, 0.2, 0.3] }],
+  credentials: {
+    tdlib: 'secure-reference-only'
+  }
+});
+
+test('agent memory encryption stores ciphertext and unlocks with platform secure storage key', async () => {
+  const secureStorage = createMockSecureStorageProvider();
+  const store = createAgentMemoryStore({ platform: 'desktop', secureStorage });
+
+  const encrypted = await store.encrypt(sampleMemory);
+
+  assert.equal(encrypted.schemaVersion, 1);
+  assert.equal(encrypted.encryption.algorithm, 'AES-256-GCM');
+  assert.equal(encrypted.encryption.keyRef, 'keychain:teleton.agentMemory.desktop.v1');
+  assert.notEqual(encrypted.ciphertext.includes('User prefers local agent mode.'), true);
+  assert.deepEqual(secureStorage.calls.map((call) => call.operation), ['get', 'set']);
+
+  const unlocked = await store.decrypt(encrypted);
+  assert.deepEqual(unlocked, sampleMemory);
+});
+
+test('agent memory encryption rejects locked and missing-key secure storage states', async () => {
+  const lockedStore = createAgentMemoryStore({
+    platform: 'ios',
+    secureStorage: createMockSecureStorageProvider({ locked: true })
+  });
+
+  await assert.rejects(() => lockedStore.encrypt(sampleMemory), /secure storage is locked/);
+
+  const secureStorage = createMockSecureStorageProvider();
+  const store = createAgentMemoryStore({ platform: 'android', secureStorage });
+  const encrypted = await store.encrypt(sampleMemory);
+  await secureStorage.delete(encrypted.encryption.keyRef);
+
+  await assert.rejects(() => store.decrypt(encrypted), /Missing secure storage key/);
+});
+
+test('agent memory migration encrypts legacy plaintext payloads and preserves encrypted payloads', async () => {
+  const secureStorage = createMockSecureStorageProvider();
+  const migrated = await migratePlainAgentMemory(sampleMemory, {
+    platform: 'desktop',
+    secureStorage
+  });
+
+  assert.equal(migrated.migrated, true);
+  assert.deepEqual(await decryptAgentMemoryPayload(migrated.payload, { secureStorage }), sampleMemory);
+
+  const unchanged = await migratePlainAgentMemory(migrated.payload, {
+    platform: 'desktop',
+    secureStorage
+  });
+
+  assert.equal(unchanged.migrated, false);
+  assert.deepEqual(unchanged.payload, migrated.payload);
+});
+
+test('agent memory key rotation re-encrypts data under a new platform key reference', async () => {
+  const secureStorage = createMockSecureStorageProvider();
+  const store = createAgentMemoryStore({ platform: 'web', secureStorage });
+  const encrypted = await encryptAgentMemoryPayload(sampleMemory, {
+    platform: 'web',
+    secureStorage
+  });
+  const rotated = await store.rotateKey(encrypted, { keyRef: 'keystore:teleton.agentMemory.web.v2' });
+
+  assert.equal(rotated.encryption.keyRef, 'keystore:teleton.agentMemory.web.v2');
+  assert.equal(rotated.encryption.purpose, AGENT_MEMORY_KEY_PURPOSE);
+  assert.deepEqual(await store.decrypt(rotated), sampleMemory);
+});

--- a/test/settings-model.test.mjs
+++ b/test/settings-model.test.mjs
@@ -25,6 +25,8 @@ test('settings defaults are serializable and keep agent and proxy disabled', () 
   assert.deepEqual(settings.proxy.entries, []);
   assert.equal(settings.notifications.enabled, true);
   assert.equal(settings.security.redactSensitiveNotifications, true);
+  assert.equal(settings.security.encryptAgentMemory, true);
+  assert.equal(settings.security.agentMemoryKeyRef, null);
   assert.deepEqual(JSON.parse(JSON.stringify(settings)), settings);
 });
 
@@ -52,6 +54,8 @@ test('settings validation rejects invalid proxy, notification, agent, and secret
       }
     },
     security: {
+      encryptAgentMemory: false,
+      agentMemoryKeyRef: 'plain-memory-key',
       secretRefs: {
         cloudAgentToken: 'raw-token'
       }
@@ -63,6 +67,8 @@ test('settings validation rejects invalid proxy, notification, agent, and secret
   assert.match(result.errors.join('\n'), /Proxy entry primary/);
   assert.match(result.errors.join('\n'), /Proxy port must be an integer/);
   assert.match(result.errors.join('\n'), /secure reference/);
+  assert.match(result.errors.join('\n'), /Agent memory encryption must remain enabled/);
+  assert.match(result.errors.join('\n'), /agentMemoryKeyRef/);
   assert.match(result.errors.join('\n'), /Quiet hours start/);
 });
 


### PR DESCRIPTION
## Summary
- Adds a foundation `agent-memory-store` contract that encrypts local agent memory, vector index payloads, and credential references with AES-256-GCM.
- Keeps raw encryption keys behind injected platform secure storage providers, with default Keychain/Keystore-style key references per platform.
- Extends security settings so agent memory encryption is enabled by default and cannot be disabled, while custom memory key refs must be secure references.
- Documents the agent memory encryption boundary in README and architecture docs.

## Reproduction / Verification
- Added `test/agent-memory-store.test.mjs` to cover encrypted-at-rest payloads, unlocked reads, locked secure storage failure, missing-key failure, legacy plaintext migration, and key rotation.

## Tests
- `npm test`
- `npm run validate:foundation`
- `npm run validate:release`

Fixes #14