### PR TITLE
[024] Implement Teleton Agent plugin system

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-26T13:39:34.663Z for PR creation at branch issue-12-b2ab9bfff1e3 for issue https://github.com/xlabtg/Teleton-Client/issues/12
 # Updated: 2026-04-26T13:57:20.603Z
+# Updated: 2026-04-26T14:03:05.822Z

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repository is in the foundation phase. The current implementation establish
 - Optional public MTProto proxy catalog metadata model that stays disabled by default and requires source freshness plus human review metadata before release.
 - Baseline TDLib client adapter contract with mock-backed tests.
 - Local Teleton Agent runtime supervisor contract with mock lifecycle tests for start, stop, health, and logs.
+- Teleton Agent plugin registry contract with manifest permissions, enable/disable/list/health bridge flows, and lifecycle permission gates.
 - Local Teleton Agent memory encryption contract using platform secure storage key providers, AES-256-GCM payloads, migration, missing-key, locked-store, and key-rotation tests.
 - CI workflow for foundation checks.
 - Documented semantic version source of truth and release metadata validation.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,6 +24,7 @@ Teleton Client is planned as a layered client where protocol, automation, wallet
 - Public MTProto proxy catalog use is opt-in and disabled by default. Catalog entries must include source URL/name, source verification notes, freshness timestamps, and per-entry human review metadata before they can be shipped.
 - Local Teleton Agent startup is represented by the `src/foundation/agent-runtime-supervisor.mjs` lifecycle boundary. Platform wrappers supply start, stop, health, and log hooks; the shared supervisor keeps the default runtime local and never requires cloud credentials for startup.
 - Teleton Agent UI communication is represented by the `src/foundation/agent-ipc-bridge.mjs` contract. It uses versioned IPC envelopes for request, event, response, error, and cancellation flows; UI layers receive incoming message hooks and can distinguish informational events from confirmation-required action proposals.
+- Teleton Agent plugins are represented by the `src/foundation/agent-plugin-registry.mjs` contract. Plugins declare permissions, lifecycle defaults, and IPC compatibility before they can be enabled. Disabled plugins cannot receive events or perform actions, and enable, disable, list, and health-check flows are routed through the agent bridge.
 - Local Teleton Agent memory is represented by the `src/foundation/agent-memory-store.mjs` contract. It encrypts memory snapshots, vector index payloads, and local credential references with AES-256-GCM while platform wrappers keep the raw data key in OS secure storage providers such as Keychain or Keystore.
 - TON signing requires user confirmation and platform secure storage or wallet-provider approval.
 
@@ -45,6 +46,12 @@ The shared supervisor exposes `start`, `stop`, `status`, `health`, and `logs` op
 The shared agent IPC bridge is transport-agnostic so desktop pipes, mobile service bindings, browser workers, HTTP, or WebSocket adapters can reuse the same contract. Version 1 envelopes include an id, kind, source, target, timestamp, and object payload. Request envelopes carry an action, event envelopes carry a typed event name, responses and errors reference `replyTo`, and cancellation envelopes reference `cancelId`.
 
 UI-facing agent events are classified by confirmation behavior. Informational updates such as `agent.info`, incoming message hooks such as `agent.message.received`, and task progress events are delivered without confirmation. Action proposals such as `agent.action.proposed` are marked `requiresConfirmation: true` before dispatch so UI shells can route them to consent flows.
+
+## Agent Plugin System
+
+The shared plugin registry normalizes plugin manifests with an id, name, version, declared permissions, lifecycle metadata, and IPC compatibility. Permission scopes are explicit and reviewable, including message read/write access, agent event delivery, agent action execution, storage access, and network access.
+
+Plugins start disabled after registration. Enabling a plugin sends an `agent.plugin.enable` request through the bridge with the normalized manifest, disabling sends `agent.plugin.disable`, list uses `agent.plugin.list`, and health checks use `agent.plugin.health`. The registry checks both lifecycle state and declared permissions before a plugin can receive agent events or perform actions, so disabled plugins cannot receive events or perform actions even if their manifest declares the relevant scope.
 
 ## Agent Memory Encryption
 

--- a/scripts/validate-foundation.mjs
+++ b/scripts/validate-foundation.mjs
@@ -26,7 +26,9 @@ const requiredFiles = [
   'docs/backlog.md',
   'docs/tdlib-adapter.md',
   'src/foundation/agent-runtime-supervisor.mjs',
-  'test/agent-runtime-supervisor.test.mjs'
+  'test/agent-runtime-supervisor.test.mjs',
+  'src/foundation/agent-plugin-registry.mjs',
+  'test/agent-plugin-registry.test.mjs'
 ];
 
 for (const requiredFile of requiredFiles) {

--- a/src/foundation/agent-ipc-bridge.mjs
+++ b/src/foundation/agent-ipc-bridge.mjs
@@ -268,6 +268,18 @@ export function createAgentIpcBridge({ localId = 'ui', remoteId = 'agent', trans
         })
       );
     },
+    listPlugins(payload = {}) {
+      return this.request('agent.plugin.list', payload);
+    },
+    enablePlugin(pluginId, payload = {}) {
+      return this.request('agent.plugin.enable', { ...payload, pluginId: normalizeId(pluginId, 'Agent plugin id') });
+    },
+    disablePlugin(pluginId, payload = {}) {
+      return this.request('agent.plugin.disable', { ...payload, pluginId: normalizeId(pluginId, 'Agent plugin id') });
+    },
+    healthCheckPlugin(pluginId, payload = {}) {
+      return this.request('agent.plugin.health', { ...payload, pluginId: normalizeId(pluginId, 'Agent plugin id') });
+    },
     receive,
     close() {
       pending.clear();

--- a/src/foundation/agent-plugin-registry.mjs
+++ b/src/foundation/agent-plugin-registry.mjs
@@ -1,0 +1,280 @@
+import { AGENT_IPC_VERSION } from './agent-ipc-bridge.mjs';
+
+export const AGENT_PLUGIN_PERMISSION_SCOPES = Object.freeze([
+  'messages.read',
+  'messages.write',
+  'agent.events.receive',
+  'agent.actions.perform',
+  'storage.read',
+  'storage.write',
+  'network.access'
+]);
+
+export const AGENT_PLUGIN_LIFECYCLE_STATES = Object.freeze(['registered', 'enabled', 'disabled', 'error']);
+export const AGENT_PLUGIN_START_MODES = Object.freeze(['manual', 'onClientStart']);
+
+const EVENT_PERMISSION_BY_TYPE = Object.freeze({
+  'agent.message.received': 'agent.events.receive',
+  'agent.task.updated': 'agent.events.receive',
+  'agent.info': 'agent.events.receive',
+  'agent.action.proposed': 'agent.events.receive'
+});
+
+const ACTION_PERMISSION_BY_NAME = Object.freeze({
+  sendMessage: 'messages.write',
+  readMessages: 'messages.read',
+  performAgentAction: 'agent.actions.perform'
+});
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeRequiredString(value, fieldName) {
+  const normalized = String(value ?? '').trim();
+
+  if (!normalized) {
+    throw new Error(`${fieldName} must be a non-empty string.`);
+  }
+
+  return normalized;
+}
+
+function normalizePermissions(value) {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error('Agent plugin manifests must declare at least one permission.');
+  }
+
+  const seen = new Set();
+
+  return value.map((permission) => {
+    if (!isPlainObject(permission)) {
+      throw new Error('Agent plugin permissions must be objects.');
+    }
+
+    const scope = normalizeRequiredString(permission.scope, 'Agent plugin permission scope');
+    if (!AGENT_PLUGIN_PERMISSION_SCOPES.includes(scope)) {
+      throw new Error(`Unsupported agent plugin permission scope: ${scope}`);
+    }
+
+    if (seen.has(scope)) {
+      throw new Error(`Duplicate agent plugin permission scope: ${scope}`);
+    }
+    seen.add(scope);
+
+    return Object.freeze({
+      scope,
+      reason: normalizeRequiredString(permission.reason, 'Agent plugin permission reason')
+    });
+  });
+}
+
+function normalizeCompatibility(value) {
+  if (!isPlainObject(value)) {
+    throw new Error('Agent plugin manifests require compatibility metadata.');
+  }
+
+  const ipcVersion = value.ipcVersion ?? AGENT_IPC_VERSION;
+  if (ipcVersion !== AGENT_IPC_VERSION) {
+    throw new Error(`Unsupported plugin IPC version: ${ipcVersion}`);
+  }
+
+  return Object.freeze({
+    ipcVersion,
+    minClientVersion:
+      value.minClientVersion === undefined
+        ? null
+        : normalizeRequiredString(value.minClientVersion, 'Agent plugin minimum client version')
+  });
+}
+
+function normalizeLifecycle(value = {}) {
+  if (!isPlainObject(value)) {
+    throw new Error('Agent plugin lifecycle metadata must be an object.');
+  }
+
+  const startMode =
+    value.startMode === undefined ? 'manual' : normalizeRequiredString(value.startMode, 'Agent plugin start mode');
+  if (!AGENT_PLUGIN_START_MODES.includes(startMode)) {
+    throw new Error(`Unsupported agent plugin start mode: ${startMode}`);
+  }
+
+  const healthTimeoutMs = value.healthTimeoutMs ?? 5000;
+  if (!Number.isInteger(healthTimeoutMs) || healthTimeoutMs <= 0) {
+    throw new Error('Agent plugin health timeout must be a positive integer.');
+  }
+
+  return Object.freeze({ startMode, healthTimeoutMs });
+}
+
+function hasPermission(record, scope) {
+  return record.manifest.permissions.some((permission) => permission.scope === scope);
+}
+
+function snapshot(record) {
+  return Object.freeze({
+    ...clone(record.manifest),
+    state: record.state,
+    enabledAt: record.enabledAt,
+    disabledAt: record.disabledAt,
+    health: clone(record.health),
+    error: record.error === null ? null : clone(record.error)
+  });
+}
+
+function toErrorRecord(error) {
+  return {
+    message: error instanceof Error ? error.message : String(error),
+    name: error instanceof Error ? error.name : 'Error'
+  };
+}
+
+export function normalizeAgentPluginManifest(input = {}) {
+  if (!isPlainObject(input)) {
+    throw new Error('Agent plugin manifest must be an object.');
+  }
+
+  return Object.freeze({
+    id: normalizeRequiredString(input.id, 'Agent plugin id'),
+    name: normalizeRequiredString(input.name, 'Agent plugin name'),
+    version: normalizeRequiredString(input.version, 'Agent plugin version'),
+    description: input.description === undefined ? '' : String(input.description),
+    permissions: Object.freeze(normalizePermissions(input.permissions)),
+    lifecycle: normalizeLifecycle(input.lifecycle),
+    compatibility: normalizeCompatibility(input.compatibility)
+  });
+}
+
+export function createAgentPluginRegistry({ bridge } = {}) {
+  if (!bridge || typeof bridge.request !== 'function') {
+    throw new Error('Agent plugin registry requires a bridge with a request hook.');
+  }
+
+  const plugins = new Map();
+
+  function getRecord(pluginId) {
+    const id = normalizeRequiredString(pluginId, 'Agent plugin id');
+    const record = plugins.get(id);
+
+    if (!record) {
+      throw new Error(`Unknown agent plugin: ${id}`);
+    }
+
+    return record;
+  }
+
+  function upsertState(pluginId, state, details = {}) {
+    const record = getRecord(pluginId);
+    record.state = state;
+    record.enabledAt = details.enabledAt ?? record.enabledAt;
+    record.disabledAt = details.disabledAt ?? record.disabledAt;
+    record.health = details.health ?? record.health;
+    record.error = details.error ?? null;
+    return snapshot(record);
+  }
+
+  return {
+    async register(manifestInput) {
+      const manifest = normalizeAgentPluginManifest(manifestInput);
+
+      if (plugins.has(manifest.id)) {
+        throw new Error(`Agent plugin already registered: ${manifest.id}`);
+      }
+
+      plugins.set(manifest.id, {
+        manifest,
+        state: 'disabled',
+        enabledAt: null,
+        disabledAt: null,
+        health: null,
+        error: null
+      });
+
+      return snapshot(plugins.get(manifest.id));
+    },
+    list() {
+      return Array.from(plugins.values(), snapshot);
+    },
+    get(pluginId) {
+      return snapshot(getRecord(pluginId));
+    },
+    async enable(pluginId) {
+      const record = getRecord(pluginId);
+
+      if (record.state === 'enabled') {
+        return snapshot(record);
+      }
+
+      try {
+        await bridge.request('agent.plugin.enable', { pluginId: record.manifest.id, manifest: clone(record.manifest) });
+        return upsertState(record.manifest.id, 'enabled', {
+          enabledAt: new Date().toISOString(),
+          disabledAt: null
+        });
+      } catch (error) {
+        return upsertState(record.manifest.id, 'error', { error: toErrorRecord(error) });
+      }
+    },
+    async disable(pluginId) {
+      const record = getRecord(pluginId);
+
+      if (record.state === 'disabled') {
+        return snapshot(record);
+      }
+
+      try {
+        await bridge.request('agent.plugin.disable', { pluginId: record.manifest.id });
+        return upsertState(record.manifest.id, 'disabled', {
+          disabledAt: new Date().toISOString()
+        });
+      } catch (error) {
+        return upsertState(record.manifest.id, 'error', { error: toErrorRecord(error) });
+      }
+    },
+    async health(pluginId) {
+      const record = getRecord(pluginId);
+      const response = await bridge.request('agent.plugin.health', { pluginId: record.manifest.id });
+      const health = response.payload?.health ?? response.payload ?? response;
+      record.health = clone(health);
+      record.error = null;
+      return clone(record.health);
+    },
+    canReceiveEvent(pluginId, eventType) {
+      const record = getRecord(pluginId);
+      const requiredPermission = EVENT_PERMISSION_BY_TYPE[eventType] ?? 'agent.events.receive';
+
+      return record.state === 'enabled' && hasPermission(record, requiredPermission);
+    },
+    canPerformAction(pluginId, action) {
+      const record = getRecord(pluginId);
+      const requiredPermission = ACTION_PERMISSION_BY_NAME[action] ?? 'agent.actions.perform';
+
+      return record.state === 'enabled' && hasPermission(record, requiredPermission);
+    }
+  };
+}
+
+export function createMockAgentPluginBridge(options = {}) {
+  const calls = [];
+
+  return {
+    calls,
+    async request(action, payload = {}) {
+      calls.push({ action, payload: clone(payload) });
+
+      if (options.errors?.[action]) {
+        throw options.errors[action];
+      }
+
+      if (action === 'agent.plugin.health') {
+        return { payload: { health: options.health?.[payload.pluginId] ?? { ok: true } } };
+      }
+
+      return { payload: { ok: true } };
+    }
+  };
+}

--- a/test/agent-ipc-bridge.test.mjs
+++ b/test/agent-ipc-bridge.test.mjs
@@ -93,6 +93,62 @@ test('agent IPC bridge supports request, response, event, and cancellation flows
   bridge.close();
 });
 
+test('agent IPC bridge exposes plugin management request helpers', async () => {
+  const transport = createMockAgentIpcTransport();
+  const bridge = createAgentIpcBridge({ transport });
+
+  const listPromise = bridge.listPlugins();
+  assert.equal(transport.sent.at(-1).action, 'agent.plugin.list');
+  transport.deliver({
+    id: 'agent.response.plugins',
+    kind: 'response',
+    source: 'agent',
+    target: 'ui',
+    replyTo: 'ui.request.1',
+    payload: { plugins: [] }
+  });
+  await listPromise;
+
+  const enablePromise = bridge.enablePlugin('summarizer');
+  assert.equal(transport.sent.at(-1).action, 'agent.plugin.enable');
+  assert.equal(transport.sent.at(-1).payload.pluginId, 'summarizer');
+  transport.deliver({
+    id: 'agent.response.enable',
+    kind: 'response',
+    source: 'agent',
+    target: 'ui',
+    replyTo: 'ui.request.2',
+    payload: { ok: true }
+  });
+  await enablePromise;
+
+  const disablePromise = bridge.disablePlugin('summarizer');
+  assert.equal(transport.sent.at(-1).action, 'agent.plugin.disable');
+  transport.deliver({
+    id: 'agent.response.disable',
+    kind: 'response',
+    source: 'agent',
+    target: 'ui',
+    replyTo: 'ui.request.3',
+    payload: { ok: true }
+  });
+  await disablePromise;
+
+  const healthPromise = bridge.healthCheckPlugin('summarizer');
+  assert.equal(transport.sent.at(-1).action, 'agent.plugin.health');
+  transport.deliver({
+    id: 'agent.response.health',
+    kind: 'response',
+    source: 'agent',
+    target: 'ui',
+    replyTo: 'ui.request.4',
+    payload: { health: { ok: true } }
+  });
+  await healthPromise;
+
+  bridge.close();
+});
+
 test('agent IPC bridge rejects malformed messages before dispatch', () => {
   assert.throws(() => parseAgentIpcEnvelope('{'), /Malformed IPC message JSON/);
   assert.throws(

--- a/test/agent-plugin-registry.test.mjs
+++ b/test/agent-plugin-registry.test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  AGENT_PLUGIN_LIFECYCLE_STATES,
+  AGENT_PLUGIN_PERMISSION_SCOPES,
+  createAgentPluginRegistry,
+  createMockAgentPluginBridge,
+  normalizeAgentPluginManifest
+} from '../src/foundation/agent-plugin-registry.mjs';
+
+test('agent plugin manifests require explicit permissions and compatibility', () => {
+  const manifest = normalizeAgentPluginManifest({
+    id: ' summarize ',
+    name: 'Summarizer',
+    version: '1.2.0',
+    permissions: [{ scope: 'messages.read', reason: 'Summarize selected chats' }],
+    compatibility: { ipcVersion: 1, minClientVersion: '0.1.0' },
+    lifecycle: { startMode: 'manual', healthTimeoutMs: 2500 }
+  });
+
+  assert.equal(manifest.id, 'summarize');
+  assert.deepEqual(manifest.permissions, [{ scope: 'messages.read', reason: 'Summarize selected chats' }]);
+  assert.equal(manifest.lifecycle.startMode, 'manual');
+  assert.equal(manifest.lifecycle.healthTimeoutMs, 2500);
+  assert.deepEqual(AGENT_PLUGIN_PERMISSION_SCOPES, [
+    'messages.read',
+    'messages.write',
+    'agent.events.receive',
+    'agent.actions.perform',
+    'storage.read',
+    'storage.write',
+    'network.access'
+  ]);
+
+  assert.throws(
+    () =>
+      normalizeAgentPluginManifest({
+        id: 'unsafe',
+        name: 'Unsafe',
+        version: '1.0.0',
+        permissions: [],
+        compatibility: { ipcVersion: 1 }
+      }),
+    /declare at least one permission/
+  );
+  assert.throws(
+    () =>
+      normalizeAgentPluginManifest({
+        id: 'future',
+        name: 'Future',
+        version: '1.0.0',
+        permissions: [{ scope: 'messages.read', reason: 'Read messages' }],
+        compatibility: { ipcVersion: 99 }
+      }),
+    /Unsupported plugin IPC version/
+  );
+});
+
+test('agent plugin registry gates lifecycle, events, and actions by enabled state and permissions', async () => {
+  const bridge = createMockAgentPluginBridge({
+    health: {
+      summarizer: { ok: true, latencyMs: 12 }
+    }
+  });
+  const registry = createAgentPluginRegistry({ bridge });
+  const registered = await registry.register({
+    id: 'summarizer',
+    name: 'Summarizer',
+    version: '1.0.0',
+    permissions: [
+      { scope: 'messages.read', reason: 'Summarize selected chats' },
+      { scope: 'agent.events.receive', reason: 'Receive message events' }
+    ],
+    compatibility: { ipcVersion: 1 }
+  });
+
+  assert.equal(registered.state, 'disabled');
+  assert.deepEqual(registry.list().map((plugin) => plugin.id), ['summarizer']);
+  assert.equal(registry.canReceiveEvent('summarizer', 'agent.message.received'), false);
+  assert.equal(registry.canPerformAction('summarizer', 'sendMessage'), false);
+
+  const enabled = await registry.enable('summarizer');
+  assert.equal(enabled.state, 'enabled');
+  assert.equal(registry.canReceiveEvent('summarizer', 'agent.message.received'), true);
+  assert.equal(registry.canPerformAction('summarizer', 'sendMessage'), false);
+  assert.deepEqual(bridge.calls.map((call) => call.action), ['agent.plugin.enable']);
+
+  const health = await registry.health('summarizer');
+  assert.deepEqual(health, { ok: true, latencyMs: 12 });
+
+  const disabled = await registry.disable('summarizer');
+  assert.equal(disabled.state, 'disabled');
+  assert.equal(registry.canReceiveEvent('summarizer', 'agent.message.received'), false);
+  assert.deepEqual(AGENT_PLUGIN_LIFECYCLE_STATES, ['registered', 'enabled', 'disabled', 'error']);
+});
+

--- a/test/foundation.test.mjs
+++ b/test/foundation.test.mjs
@@ -217,6 +217,30 @@ test('agent IPC bridge exposes versioned envelopes and confirmation-aware UI eve
   assert.equal(proposal.requiresConfirmation, true);
 });
 
+test('agent plugin registry requires permissions and blocks disabled plugins', async () => {
+  const { createAgentPluginRegistry, createMockAgentPluginBridge } = await import(
+    '../src/foundation/agent-plugin-registry.mjs'
+  );
+  const architecture = await readFile(pathFor('docs/architecture.md'), 'utf8');
+
+  const registry = createAgentPluginRegistry({ bridge: createMockAgentPluginBridge() });
+  await registry.register({
+    id: 'summarizer',
+    name: 'Summarizer',
+    version: '1.0.0',
+    permissions: [{ scope: 'agent.events.receive', reason: 'Receive selected agent events' }],
+    compatibility: { ipcVersion: 1 }
+  });
+
+  assert.equal(registry.canReceiveEvent('summarizer', 'agent.message.received'), false);
+  await registry.enable('summarizer');
+  assert.equal(registry.canReceiveEvent('summarizer', 'agent.message.received'), true);
+  await registry.disable('summarizer');
+  assert.equal(registry.canReceiveEvent('summarizer', 'agent.message.received'), false);
+  assert.match(architecture, /Plugins declare permissions/i);
+  assert.match(architecture, /Disabled plugins cannot receive events/i);
+});
+
 test('proxy settings model covers supported proxy types without hardcoded secrets', async () => {
   const { PROXY_PROTOCOLS, validateProxyConfig } = await import('../src/foundation/proxy-settings.mjs');
   const { PROXY_ROUTE_TYPES, createProxyManager } = await import('../src/foundation/proxy-manager.mjs');


### PR DESCRIPTION
## Summary
- Add a shared Teleton Agent plugin registry contract with manifest normalization, permission scopes, lifecycle state, compatibility checks, and health snapshots.
- Add agent IPC bridge helpers for plugin list, enable, disable, and health-check request flows.
- Document the plugin system in architecture/current capabilities and add foundation validation coverage.

## Reproduction and Verification
- Reproducing coverage: test/agent-plugin-registry.test.mjs verifies invalid manifests, permission boundaries, enabled/disabled lifecycle behavior, and health checks.
- Bridge coverage: test/agent-ipc-bridge.test.mjs verifies plugin management actions are sent through the IPC bridge.

## Tests
- npm test
- npm run validate:foundation
- npm run validate:release
- npm run decompose:dry-run

## Risk / Follow-up
- This is a foundation contract with mock bridge coverage only; concrete platform plugin loading and runtime packaging remain future Teleton Agent integration work.

Fixes #46