### PR TITLE
Add custom LLM provider configuration

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-26T13:39:34.663Z for PR creation at branch issue-12-b2ab9bfff1e3 for issue https://github.com/xlabtg/Teleton-Client/issues/12
 # Updated: 2026-04-26T13:57:20.603Z
+# Updated: 2026-04-26T14:06:10.756Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-26T13:39:34.663Z for PR creation at branch issue-12-b2ab9bfff1e3 for issue https://github.com/xlabtg/Teleton-Client/issues/12
-# Updated: 2026-04-26T13:57:20.603Z
-# Updated: 2026-04-26T14:06:10.756Z

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -11,6 +11,7 @@ This repository currently contains foundation automation, configuration models, 
 - Chat data must remain local unless the user explicitly enables cloud or hybrid agent mode.
 - AI models must not be trained on private chat content by default.
 - Autonomous agent actions must require clear user consent and configurable limits.
+- LLM provider credentials must be stored as secure references such as `env:NAME`, `keychain:name`, `keystore:name`, or `secret:name`; raw API keys and tokens must not be committed to settings, logs, issues, or pull requests.
 - Proxy credentials and MTProto secrets must be represented by secure references, not hardcoded values.
 - TON private keys and wallet credentials must use platform secure storage or user-approved wallet providers.
 
@@ -18,9 +19,13 @@ This repository currently contains foundation automation, configuration models, 
 
 Telegram traffic will be handled through TDLib and optional user-configured proxies. Agent traffic will use a local IPC bridge by default, with cloud processing available only through an explicit setting. TON operations will use TON SDK or wallet-provider integrations and require confirmation for transactions.
 
+Agent provider configuration supports local runtimes, approved cloud providers, and approved custom HTTPS endpoints. Local providers keep prompts, message context, and model execution on the device or local bridge and do not store shared provider credentials. Cloud and custom endpoint providers may receive selected prompts, message context, action metadata, and provider telemetry after explicit cloud processing opt-in. Their API keys and bearer tokens are represented only through secure references resolved by platform secure storage at runtime.
+
 ## User Controls
 
 The planned agent modes are `off`, `local`, `cloud`, and `hybrid`. The default is `off`. Users must be able to switch modes, set action limits, review sensitive actions, and disable automation without losing access to standard messaging features.
+
+Cloud-capable provider use requires explicit cloud processing opt-in before activation. Users can clear or replace provider references without exposing the underlying credential value through shared settings snapshots.
 
 ## Security Reporting
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,8 @@ Teleton Client is planned as a layered client where protocol, automation, wallet
 - TDLib credentials must be supplied at runtime and never committed.
 - TDLib callers use the shared `authenticate`, `getChatList`, `sendMessage`, and `subscribeUpdates` adapter contract so Android, iOS, desktop, and web-compatible bridges expose the same boundary.
 - Agent mode defaults to `off`; cloud and hybrid modes require explicit activation.
-- Agent settings UI shells use shared view state for mode options, model provider preferences, privacy impact prompts, approval preferences, and autonomous action limits. Cloud and hybrid activation stays pending until the user confirms the privacy impact summary.
+- Agent settings UI shells use shared view state for mode options, model provider preferences, LLM provider configuration, privacy impact prompts, approval preferences, and autonomous action limits. Cloud and hybrid activation stays pending until the user confirms the privacy impact summary.
+- LLM provider credentials use secure references such as `env:NAME`, `keychain:name`, `keystore:name`, or `secret:name`. Local providers cannot persist shared credentials, while cloud and custom HTTPS endpoint providers require explicit cloud processing opt-in before use.
 - Proxy secrets are represented as secure references such as `env:NAME`, `keychain:name`, or `keystore:name`.
 - Proxy settings UI shells use shared view state for list items, edit forms, test status, auto-switch preferences, and active route metadata. Display snapshots expose only configured flags for secrets, while settings persistence keeps secure references for platform storage resolution.
 - Proxy usage statistics are local diagnostics records keyed by proxy id. They track attempts, successes, failures, latency samples, and last-used time separately from proxy configuration and never include proxy secrets or message contents.
@@ -56,7 +57,7 @@ Platform wrappers supply a secure storage provider with `get` and `set` hooks. T
 
 The shared agent settings view state is implemented in `src/foundation/agent-settings-view.mjs`. It exposes the canonical `off`, `local`, `cloud`, and `hybrid` mode controls from the settings model, keeps the default mode off, and blocks cloud-capable mode changes behind an explicit privacy impact confirmation step before enabling cloud processing consent.
 
-The view also carries model provider/model id preferences, confirmation requirements, and the per-hour autonomous action limit. Platform UI shells can render this state directly while persisting only the validated shared agent settings payload.
+The view also carries model provider/model id preferences, provider configuration types, confirmation requirements, and the per-hour autonomous action limit. Provider configuration supports local endpoints, approved cloud providers, and approved custom HTTPS endpoints. Shared validation rejects raw API keys or tokens, requires secure credential references for cloud providers, and blocks cloud-capable providers until the user has opted in to cloud processing. Platform UI shells can render this state directly while persisting only the validated shared agent settings payload.
 
 ## Foundation Status
 

--- a/src/foundation/agent-provider-config.mjs
+++ b/src/foundation/agent-provider-config.mjs
@@ -1,0 +1,137 @@
+export const AGENT_PROVIDER_TYPES = Object.freeze(['local', 'cloud', 'custom-endpoint']);
+export const AGENT_PROVIDER_SECRET_FIELDS = Object.freeze(['apiKeyRef', 'tokenRef']);
+
+const PROVIDER_ID_PATTERN = /^[A-Za-z0-9_.:-]+$/;
+const MODEL_ID_PATTERN = /^[A-Za-z0-9_.:/-]+$/;
+const LOCAL_ENDPOINT_PROTOCOLS = Object.freeze(['http:', 'ipc:', 'unix:']);
+const CLOUD_ENDPOINT_PROTOCOLS = Object.freeze(['https:']);
+const SECURE_REFERENCE_PATTERN = /^(?:env|keychain|keystore|secret):[A-Za-z0-9_.:/-]+$/;
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function isSecureReference(value) {
+  return typeof value === 'string' && SECURE_REFERENCE_PATTERN.test(value.trim());
+}
+
+function normalizeOptionalString(value) {
+  const normalized = String(value ?? '').trim();
+  return normalized || null;
+}
+
+function validateEndpointUrl(value, allowedProtocols, label, errors) {
+  const endpointUrl = normalizeOptionalString(value);
+
+  if (!endpointUrl) {
+    return null;
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(endpointUrl);
+  } catch {
+    errors.push(`${label} endpointUrl must be a valid URL.`);
+    return endpointUrl;
+  }
+
+  if (!allowedProtocols.includes(parsed.protocol)) {
+    errors.push(`${label} endpointUrl must use one of: ${allowedProtocols.join(', ')}.`);
+  }
+
+  return endpointUrl;
+}
+
+export function normalizeAgentProviderConfig(input = {}) {
+  const errors = [];
+
+  if (!isPlainObject(input)) {
+    return {
+      valid: false,
+      errors: ['Agent provider configuration must be an object.'],
+      config: null
+    };
+  }
+
+  const id = String(input.id ?? '').trim();
+  const type = String(input.type ?? '').trim();
+  const modelId = String(input.modelId ?? '').trim();
+
+  const config = {
+    id,
+    type,
+    modelId
+  };
+
+  if (!id || !PROVIDER_ID_PATTERN.test(id)) {
+    errors.push('Agent provider id must use letters, numbers, dots, dashes, underscores, or colons.');
+  }
+
+  if (!AGENT_PROVIDER_TYPES.includes(type)) {
+    errors.push(`Agent provider type must be one of: ${AGENT_PROVIDER_TYPES.join(', ')}.`);
+  }
+
+  if (!modelId || !MODEL_ID_PATTERN.test(modelId)) {
+    errors.push('Agent provider modelId is required and must not contain spaces.');
+  }
+
+  const displayName = normalizeOptionalString(input.displayName);
+  if (displayName) {
+    config.displayName = displayName;
+  }
+
+  if (type === 'local') {
+    config.endpointUrl = validateEndpointUrl(input.endpointUrl, LOCAL_ENDPOINT_PROTOCOLS, 'Local provider', errors);
+    if (input.apiKeyRef !== undefined || input.tokenRef !== undefined) {
+      errors.push('Local provider credentials are not stored in shared settings.');
+    }
+  }
+
+  if (type === 'cloud') {
+    config.endpointUrl = validateEndpointUrl(input.endpointUrl, CLOUD_ENDPOINT_PROTOCOLS, 'Cloud provider', errors);
+    const credentialRef = input.apiKeyRef ?? input.tokenRef;
+
+    if (!isSecureReference(credentialRef)) {
+      errors.push('Cloud provider credentials must use apiKeyRef or tokenRef secure references.');
+    } else if (input.apiKeyRef !== undefined) {
+      config.apiKeyRef = String(input.apiKeyRef).trim();
+    } else {
+      config.tokenRef = String(input.tokenRef).trim();
+    }
+
+    config.requiresCloudOptIn = true;
+  }
+
+  if (type === 'custom-endpoint') {
+    config.endpointUrl = validateEndpointUrl(input.endpointUrl, CLOUD_ENDPOINT_PROTOCOLS, 'Custom endpoint provider', errors);
+    const credentialRef = input.apiKeyRef ?? input.tokenRef;
+
+    if (credentialRef !== undefined) {
+      if (!isSecureReference(credentialRef)) {
+        errors.push('Custom endpoint credentials must use secure references when configured.');
+      } else if (input.apiKeyRef !== undefined) {
+        config.apiKeyRef = String(input.apiKeyRef).trim();
+      } else {
+        config.tokenRef = String(input.tokenRef).trim();
+      }
+    }
+
+    config.requiresCloudOptIn = true;
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    config
+  };
+}
+
+export function validateAgentProviderConfig(input = {}) {
+  const result = normalizeAgentProviderConfig(input);
+
+  return {
+    valid: result.valid,
+    errors: result.errors,
+    config: result.config
+  };
+}

--- a/src/foundation/agent-settings-view.mjs
+++ b/src/foundation/agent-settings-view.mjs
@@ -1,4 +1,5 @@
 import { AGENT_MODES, createAgentSettings, normalizeAgentMode, validateAgentSettings } from './agent-settings.mjs';
+import { AGENT_PROVIDER_TYPES, normalizeAgentProviderConfig } from './agent-provider-config.mjs';
 
 export const AGENT_PRIVACY_IMPACT_MODES = Object.freeze(['cloud', 'hybrid']);
 
@@ -135,6 +136,10 @@ export function createAgentSettingsView(options = {}) {
         providers: AGENT_MODEL_PROVIDERS.map((provider) => ({ id: provider })),
         selected: clone(settings.model)
       },
+      providerConfig: {
+        types: AGENT_PROVIDER_TYPES.map((type) => ({ id: type })),
+        selected: clone(settings.providerConfig)
+      },
       privacy: {
         allowCloudProcessing: settings.allowCloudProcessing,
         impacts: clone(PRIVACY_IMPACT)
@@ -192,6 +197,24 @@ export function createAgentSettingsView(options = {}) {
       return save({
         ...settings,
         model: normalizeModelPreference(value)
+      });
+    },
+    setProviderConfig(value) {
+      const validation = normalizeAgentProviderConfig(value);
+
+      if (!validation.valid) {
+        throw new Error(validation.errors.join(' '));
+      }
+
+      return save({
+        ...settings,
+        providerConfig: validation.config
+      });
+    },
+    clearProviderConfig() {
+      return save({
+        ...settings,
+        providerConfig: null
       });
     },
     setRequireConfirmation(value) {

--- a/src/foundation/agent-settings.mjs
+++ b/src/foundation/agent-settings.mjs
@@ -1,3 +1,5 @@
+import { normalizeAgentProviderConfig } from './agent-provider-config.mjs';
+
 export const AGENT_MODES = Object.freeze(['off', 'local', 'cloud', 'hybrid']);
 
 const MODE_ALIASES = new Map([
@@ -26,10 +28,12 @@ export function normalizeAgentMode(value) {
 
 export function createAgentSettings(input = {}) {
   const mode = input.mode === undefined ? 'off' : normalizeAgentMode(input.mode);
+  const providerConfig = input.providerConfig === undefined ? null : input.providerConfig;
 
   return {
     mode,
     model: input.model ?? null,
+    providerConfig,
     requireConfirmation: input.requireConfirmation ?? true,
     allowCloudProcessing: mode === 'cloud' || mode === 'hybrid' ? input.allowCloudProcessing === true : false,
     maxAutonomousActionsPerHour: Number.isInteger(input.maxAutonomousActionsPerHour)
@@ -55,6 +59,23 @@ export function validateAgentSettings(input = {}) {
 
     if ((settings.mode === 'cloud' || settings.mode === 'hybrid') && settings.allowCloudProcessing !== true) {
       errors.push('Cloud and hybrid modes require explicit cloud processing consent.');
+    }
+
+    if (settings.providerConfig !== null) {
+      const providerValidation = normalizeAgentProviderConfig(settings.providerConfig);
+      settings.providerConfig = providerValidation.config;
+
+      for (const error of providerValidation.errors) {
+        errors.push(`Agent provider ${settings.providerConfig?.id || 'configuration'}: ${error}`);
+      }
+
+      if (
+        providerValidation.valid &&
+        settings.providerConfig.requiresCloudOptIn === true &&
+        settings.allowCloudProcessing !== true
+      ) {
+        errors.push('Cloud provider use requires explicit user opt-in.');
+      }
     }
 
     if (settings.maxAutonomousActionsPerHour < 0) {

--- a/src/foundation/settings-model.mjs
+++ b/src/foundation/settings-model.mjs
@@ -36,6 +36,7 @@ export const DEFAULT_TELETON_SETTINGS = deepFreeze({
   agent: {
     mode: 'off',
     model: null,
+    providerConfig: null,
     requireConfirmation: true,
     allowCloudProcessing: false,
     maxAutonomousActionsPerHour: 0

--- a/test/agent-provider-config.test.mjs
+++ b/test/agent-provider-config.test.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  AGENT_PROVIDER_TYPES,
+  isSecureReference,
+  validateAgentProviderConfig
+} from '../src/foundation/agent-provider-config.mjs';
+
+test('agent provider config validates local providers without shared credentials', () => {
+  assert.deepEqual(AGENT_PROVIDER_TYPES, ['local', 'cloud', 'custom-endpoint']);
+
+  const valid = validateAgentProviderConfig({
+    id: 'ollama-local',
+    type: 'local',
+    modelId: 'llama3.2',
+    endpointUrl: 'http://127.0.0.1:11434'
+  });
+
+  assert.equal(valid.valid, true);
+  assert.equal(valid.config.endpointUrl, 'http://127.0.0.1:11434');
+
+  const invalid = validateAgentProviderConfig({
+    id: 'local-with-secret',
+    type: 'local',
+    modelId: 'local-model',
+    endpointUrl: 'https://local.example',
+    apiKeyRef: 'env:SHOULD_NOT_BE_USED'
+  });
+
+  assert.equal(invalid.valid, false);
+  assert.match(invalid.errors.join('\n'), /Local provider endpointUrl/);
+  assert.match(invalid.errors.join('\n'), /credentials are not stored/);
+});
+
+test('agent provider config requires secure credential references for cloud providers', () => {
+  const valid = validateAgentProviderConfig({
+    id: 'openai',
+    type: 'cloud',
+    modelId: 'gpt-4.1-mini',
+    endpointUrl: 'https://api.openai.com/v1',
+    apiKeyRef: 'keychain:teleton-openai-api-key'
+  });
+
+  assert.equal(valid.valid, true);
+  assert.equal(valid.config.requiresCloudOptIn, true);
+  assert.equal(valid.config.apiKeyRef, 'keychain:teleton-openai-api-key');
+  assert.equal(isSecureReference('env:TELETON_AGENT_TOKEN'), true);
+  assert.equal(isSecureReference('raw-token'), false);
+
+  const invalid = validateAgentProviderConfig({
+    id: 'cloud',
+    type: 'cloud',
+    modelId: 'remote-model',
+    endpointUrl: 'http://api.example.test',
+    apiKeyRef: 'raw-token'
+  });
+
+  assert.equal(invalid.valid, false);
+  assert.match(invalid.errors.join('\n'), /https:/);
+  assert.match(invalid.errors.join('\n'), /secure references/);
+});
+
+test('agent provider config validates custom endpoint providers', () => {
+  const valid = validateAgentProviderConfig({
+    id: 'approved-custom',
+    type: 'custom-endpoint',
+    modelId: 'vendor/model-v1',
+    endpointUrl: 'https://llm.example.test/v1',
+    tokenRef: 'secret:approved-custom-token'
+  });
+
+  assert.equal(valid.valid, true);
+  assert.equal(valid.config.tokenRef, 'secret:approved-custom-token');
+  assert.equal(valid.config.requiresCloudOptIn, true);
+
+  const invalid = validateAgentProviderConfig({
+    id: 'bad custom',
+    type: 'custom-endpoint',
+    modelId: 'model with spaces',
+    endpointUrl: 'not-a-url'
+  });
+
+  assert.equal(invalid.valid, false);
+  assert.match(invalid.errors.join('\n'), /provider id/);
+  assert.match(invalid.errors.join('\n'), /modelId/);
+  assert.match(invalid.errors.join('\n'), /valid URL/);
+});

--- a/test/agent-settings-view.test.mjs
+++ b/test/agent-settings-view.test.mjs
@@ -74,3 +74,44 @@ test('agent settings view activates local mode without cloud privacy consent', (
   assert.equal(state.activation.pending, false);
   assert.deepEqual(AGENT_PRIVACY_IMPACT_MODES, ['cloud', 'hybrid']);
 });
+
+test('agent settings view stores validated provider configs and blocks cloud providers without consent', () => {
+  const view = createAgentSettingsView();
+
+  let state = view.setProviderConfig({
+    id: 'local-runtime',
+    type: 'local',
+    modelId: 'llama3.2',
+    endpointUrl: 'http://127.0.0.1:11434'
+  });
+
+  assert.equal(state.providerConfig.selected.id, 'local-runtime');
+  assert.equal(state.settings.providerConfig.type, 'local');
+  assert.throws(
+    () =>
+      view.setProviderConfig({
+        id: 'cloud-runtime',
+        type: 'cloud',
+        modelId: 'remote-model',
+        endpointUrl: 'https://api.example.test/v1',
+        apiKeyRef: 'env:TELETON_AGENT_API_KEY'
+      }),
+    /explicit user opt-in/
+  );
+
+  state = view.selectMode('cloud');
+  assert.equal(state.activation.pending, true);
+  view.confirmPrivacyImpact();
+
+  state = view.setProviderConfig({
+    id: 'cloud-runtime',
+    type: 'cloud',
+    modelId: 'remote-model',
+    endpointUrl: 'https://api.example.test/v1',
+    apiKeyRef: 'env:TELETON_AGENT_API_KEY'
+  });
+
+  assert.equal(state.settings.providerConfig.apiKeyRef, 'env:TELETON_AGENT_API_KEY');
+  state = view.clearProviderConfig();
+  assert.equal(state.settings.providerConfig, null);
+});

--- a/test/foundation.test.mjs
+++ b/test/foundation.test.mjs
@@ -175,6 +175,37 @@ test('agent settings view requires consent before cloud-capable modes', async ()
   assert.equal(confirmed.settings.allowCloudProcessing, true);
 });
 
+test('agent provider configuration keeps credentials in secure references', async () => {
+  const { AGENT_PROVIDER_TYPES, validateAgentProviderConfig } = await import(
+    '../src/foundation/agent-provider-config.mjs'
+  );
+  const privacy = await readFile(pathFor('PRIVACY.md'), 'utf8');
+
+  assert.deepEqual(AGENT_PROVIDER_TYPES, ['local', 'cloud', 'custom-endpoint']);
+  assert.equal(
+    validateAgentProviderConfig({
+      id: 'approved-custom',
+      type: 'custom-endpoint',
+      modelId: 'vendor/model-v1',
+      endpointUrl: 'https://llm.example.test/v1',
+      tokenRef: 'secret:approved-custom-token'
+    }).valid,
+    true
+  );
+  assert.equal(
+    validateAgentProviderConfig({
+      id: 'cloud',
+      type: 'cloud',
+      modelId: 'remote-model',
+      endpointUrl: 'https://api.example.test/v1',
+      tokenRef: 'raw-token'
+    }).valid,
+    false
+  );
+  assert.match(privacy, /LLM provider credentials/i);
+  assert.match(privacy, /explicit cloud processing opt-in/i);
+});
+
 test('local agent runtime lifecycle boundary is documented and credential-free by default', async () => {
   const { AGENT_RUNTIME_PLATFORMS, describeAgentRuntimeSupport } = await import(
     '../src/foundation/agent-runtime-supervisor.mjs'

--- a/test/settings-model.test.mjs
+++ b/test/settings-model.test.mjs
@@ -72,6 +72,60 @@ test('settings validation rejects invalid proxy, notification, agent, and secret
   assert.match(result.errors.join('\n'), /Quiet hours start/);
 });
 
+test('settings validation enforces agent provider secrets and cloud opt-in', () => {
+  const invalid = validateTeletonSettings({
+    agent: {
+      mode: 'local',
+      allowCloudProcessing: false,
+      providerConfig: {
+        id: 'custom-provider',
+        type: 'custom-endpoint',
+        modelId: 'vendor/model',
+        endpointUrl: 'https://llm.example.test/v1',
+        apiKeyRef: 'env:TELETON_CUSTOM_LLM_KEY'
+      }
+    }
+  });
+
+  assert.equal(invalid.valid, false);
+  assert.match(invalid.errors.join('\n'), /explicit user opt-in/);
+
+  const rawCredential = validateTeletonSettings({
+    agent: {
+      mode: 'cloud',
+      allowCloudProcessing: true,
+      providerConfig: {
+        id: 'custom-provider',
+        type: 'custom-endpoint',
+        modelId: 'vendor/model',
+        endpointUrl: 'https://llm.example.test/v1',
+        apiKeyRef: 'raw-api-key'
+      }
+    }
+  });
+
+  assert.equal(rawCredential.valid, false);
+  assert.match(rawCredential.errors.join('\n'), /secure references/);
+
+  const valid = validateTeletonSettings({
+    agent: {
+      mode: 'cloud',
+      allowCloudProcessing: true,
+      providerConfig: {
+        id: 'teleton-cloud',
+        type: 'cloud',
+        modelId: 'teleton-cloud-default',
+        endpointUrl: 'https://agent.teleton.example/v1',
+        tokenRef: 'keychain:teleton-agent-token'
+      }
+    }
+  });
+
+  assert.equal(valid.valid, true);
+  assert.equal(valid.settings.agent.providerConfig.tokenRef, 'keychain:teleton-agent-token');
+  assert.equal(valid.settings.agent.providerConfig.requiresCloudOptIn, true);
+});
+
 test('settings model produces valid platform snapshots for every wrapper', () => {
   assert.deepEqual(SETTINGS_PLATFORM_WRAPPERS, ['android', 'ios', 'desktop', 'web']);
 


### PR DESCRIPTION
## Summary

- Adds a shared agent provider configuration schema for local, cloud, and approved custom endpoint LLM providers.
- Validates provider ids, model ids, endpoint protocols, secure credential references, and cloud-provider opt-in through agent settings.
- Exposes provider configuration state/actions in the shared agent settings view and documents privacy behavior.

## Issue

Fixes #47

## Tests

- [x] `npm test`
- [x] `npm run validate:foundation`
- [x] `npm run validate:release`
- [x] `npm run decompose:dry-run`
- [x] Manual checks, if relevant: Not applicable; foundation model and documentation change only.

## Risk

- Low. This extends foundation settings validation and defaults; no production provider calls or credential resolution are implemented here.

## Screenshots or recordings

Not applicable.

## Security and privacy

- [x] This PR does not include secrets, production credentials, access tokens, Telegram API hashes, private keys, or private message content.
- [x] Any logs, screenshots, or fixtures are redacted.
