### PR TITLE
Implement portable agent configuration import and export

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-04-26T13:39:34.663Z for PR creation at branch issue-12-b2ab9bfff1e3 for issue https://github.com/xlabtg/Teleton-Client/issues/12
 # Updated: 2026-04-26T13:57:20.603Z
 # Updated: 2026-04-26T14:03:05.822Z
+# Updated: 2026-04-26T14:08:43.419Z

--- a/src/foundation/agent-settings-view.mjs
+++ b/src/foundation/agent-settings-view.mjs
@@ -1,6 +1,8 @@
 import { AGENT_MODES, createAgentSettings, normalizeAgentMode, validateAgentSettings } from './agent-settings.mjs';
 
 export const AGENT_PRIVACY_IMPACT_MODES = Object.freeze(['cloud', 'hybrid']);
+export const AGENT_SETTINGS_EXPORT_KIND = 'teleton.agent.settings.export';
+export const AGENT_SETTINGS_EXCLUDED_FIELDS = Object.freeze(['memory', 'token', 'apiKey', 'secret']);
 
 export const AGENT_MODEL_PROVIDERS = Object.freeze(['local', 'openai', 'teleton-cloud', 'custom']);
 
@@ -110,6 +112,76 @@ function normalizeActionLimit(value, mode) {
   return mode === 'off' ? 0 : limit;
 }
 
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function redactPortableAgentSettings(input) {
+  const portable = clone(input);
+
+  for (const field of AGENT_SETTINGS_EXCLUDED_FIELDS) {
+    delete portable[field];
+  }
+
+  return portable;
+}
+
+function collectChanges(before, after, prefix = '') {
+  const changes = [];
+  const keys = new Set([...Object.keys(before ?? {}), ...Object.keys(after ?? {})]);
+
+  for (const key of keys) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    const previous = before?.[key];
+    const next = after?.[key];
+
+    if (isPlainObject(previous) && isPlainObject(next)) {
+      changes.push(...collectChanges(previous, next, path));
+    } else if (JSON.stringify(previous) !== JSON.stringify(next)) {
+      changes.push({ path, before: clone(previous), after: clone(next) });
+    }
+  }
+
+  return changes;
+}
+
+function previewPortableAgentSettingsImport(payload, currentSettings) {
+  if (!isPlainObject(payload)) {
+    throw new Error('Agent settings import payload must be an object.');
+  }
+
+  if (payload.kind !== AGENT_SETTINGS_EXPORT_KIND) {
+    throw new Error(`Unsupported agent settings export kind: ${payload.kind}.`);
+  }
+
+  if (!Number.isInteger(payload.schemaVersion)) {
+    throw new Error('Agent settings import schemaVersion must be an integer.');
+  }
+
+  if (payload.schemaVersion > 1) {
+    throw new Error(`Agent settings schema version ${payload.schemaVersion} is newer than this client supports (1).`);
+  }
+
+  if (!isPlainObject(payload.settings)) {
+    throw new Error('Agent settings import settings must be an object.');
+  }
+
+  const candidate = {
+    ...currentSettings,
+    ...redactPortableAgentSettings(payload.settings)
+  };
+  const validation = validateAgentSettings(candidate);
+
+  return {
+    valid: validation.valid,
+    errors: validation.errors,
+    schemaVersion: payload.schemaVersion,
+    excludedFields: [...AGENT_SETTINGS_EXCLUDED_FIELDS],
+    changes: validation.settings ? collectChanges(currentSettings, validation.settings) : [],
+    settings: validation.settings
+  };
+}
+
 export function createAgentSettingsView(options = {}) {
   let settings = createAgentSettings(options.initialSettings);
   let pendingMode = null;
@@ -208,6 +280,28 @@ export function createAgentSettingsView(options = {}) {
     },
     exportSettings() {
       return clone(settings);
+    },
+    exportPortableSettings() {
+      return {
+        kind: AGENT_SETTINGS_EXPORT_KIND,
+        schemaVersion: 1,
+        excludedFields: [...AGENT_SETTINGS_EXCLUDED_FIELDS],
+        settings: redactPortableAgentSettings(settings)
+      };
+    },
+    previewImport(payload) {
+      return previewPortableAgentSettingsImport(payload, settings);
+    },
+    applyImport(payloadOrPreview) {
+      const preview = payloadOrPreview?.valid === true && payloadOrPreview.settings
+        ? payloadOrPreview
+        : previewPortableAgentSettingsImport(payloadOrPreview, settings);
+
+      if (!preview.valid) {
+        throw new Error(preview.errors.join(' '));
+      }
+
+      return save(preview.settings);
     }
   });
 }

--- a/src/foundation/settings-model.mjs
+++ b/src/foundation/settings-model.mjs
@@ -3,6 +3,15 @@ import { createPublicProxyCatalog, validatePublicProxyCatalog } from './public-p
 import { isSecureReference, validateProxyConfig } from './proxy-settings.mjs';
 
 export const SETTINGS_SCHEMA_VERSION = 1;
+export const PORTABLE_SETTINGS_EXPORT_KIND = 'teleton.settings.export';
+export const PORTABLE_SETTINGS_EXCLUDED_FIELDS = Object.freeze([
+  'proxy.entries[].secretRef',
+  'proxy.entries[].usernameRef',
+  'proxy.entries[].passwordRef',
+  'security.agentMemoryKeyRef',
+  'security.secretRefs',
+  'agent.memory'
+]);
 export const SETTINGS_PLATFORM_WRAPPERS = Object.freeze(['android', 'ios', 'desktop', 'web']);
 export const SETTINGS_THEMES = Object.freeze(['system', 'light', 'dark']);
 
@@ -78,6 +87,100 @@ function clone(value) {
 
 function isPlainObject(value) {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function mergePlainObject(base, overlay) {
+  const merged = { ...base };
+
+  for (const [key, value] of Object.entries(overlay)) {
+    if (isPlainObject(value) && isPlainObject(base[key])) {
+      merged[key] = mergePlainObject(base[key], value);
+    } else {
+      merged[key] = value;
+    }
+  }
+
+  return merged;
+}
+
+function redactPortableSettings(settings) {
+  const portable = clone(settings);
+  delete portable.platform;
+
+  if (portable.proxy?.entries) {
+    portable.proxy.entries = portable.proxy.entries.map((entry) => {
+      const safeEntry = { ...entry };
+      delete safeEntry.secretRef;
+      delete safeEntry.usernameRef;
+      delete safeEntry.passwordRef;
+      return safeEntry;
+    });
+  }
+
+  if (portable.security) {
+    delete portable.security.agentMemoryKeyRef;
+    delete portable.security.secretRefs;
+  }
+
+  if (portable.agent) {
+    delete portable.agent.memory;
+  }
+
+  return portable;
+}
+
+function normalizePortableEnvelope(payload) {
+  if (!isPlainObject(payload)) {
+    throw new Error('Portable settings import payload must be an object.');
+  }
+
+  if (payload.kind !== undefined && payload.kind !== PORTABLE_SETTINGS_EXPORT_KIND) {
+    throw new Error(`Unsupported portable settings export kind: ${payload.kind}.`);
+  }
+
+  const schemaVersion = payload.schemaVersion;
+  if (!Number.isInteger(schemaVersion)) {
+    throw new Error('Portable settings import schemaVersion must be an integer.');
+  }
+
+  if (schemaVersion > SETTINGS_SCHEMA_VERSION) {
+    throw new Error(
+      `Portable settings schema version ${schemaVersion} is newer than this client supports (${SETTINGS_SCHEMA_VERSION}).`
+    );
+  }
+
+  if (schemaVersion < 0) {
+    throw new Error(`Unsupported portable settings schema version: ${schemaVersion}.`);
+  }
+
+  if (!isPlainObject(payload.settings)) {
+    throw new Error('Portable settings import settings must be an object.');
+  }
+
+  return payload;
+}
+
+function collectChanges(before, after, prefix = '') {
+  const changes = [];
+  const keys = new Set([...Object.keys(before ?? {}), ...Object.keys(after ?? {})]);
+
+  for (const key of keys) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    const previous = before?.[key];
+    const next = after?.[key];
+
+    if (isPlainObject(previous) && isPlainObject(next)) {
+      changes.push(...collectChanges(previous, next, path));
+    } else if (JSON.stringify(previous) !== JSON.stringify(next)) {
+      changes.push({
+        path,
+        before: previous === undefined ? undefined : clone(previous),
+        after: next === undefined ? undefined : clone(next)
+      });
+    }
+  }
+
+  return changes;
 }
 
 function normalizePlatform(value) {
@@ -481,6 +584,57 @@ export function createPlatformSettings(platform, input = {}) {
     ...input,
     platform: normalizePlatform(platform)
   });
+}
+
+export function exportPortableTeletonSettings(input = {}) {
+  const settings = createTeletonSettings(input);
+
+  return {
+    kind: PORTABLE_SETTINGS_EXPORT_KIND,
+    schemaVersion: SETTINGS_SCHEMA_VERSION,
+    excludedFields: [...PORTABLE_SETTINGS_EXCLUDED_FIELDS],
+    settings: redactPortableSettings(settings)
+  };
+}
+
+export function previewPortableTeletonSettingsImport(payload, options = {}) {
+  let envelope;
+
+  try {
+    envelope = normalizePortableEnvelope(payload);
+  } catch (error) {
+    return {
+      valid: false,
+      errors: [error.message],
+      schemaVersion: isPlainObject(payload) ? payload.schemaVersion : undefined,
+      excludedFields: [...PORTABLE_SETTINGS_EXCLUDED_FIELDS],
+      changes: [],
+      settings: undefined
+    };
+  }
+
+  const currentSettings = createTeletonSettings(options.currentSettings);
+  const mergedSettings = mergePlainObject(currentSettings, redactPortableSettings(envelope.settings));
+  const validation = validateTeletonSettings(mergedSettings);
+
+  return {
+    valid: validation.valid,
+    errors: validation.errors,
+    schemaVersion: envelope.schemaVersion,
+    excludedFields: [...PORTABLE_SETTINGS_EXCLUDED_FIELDS],
+    changes: validation.settings ? collectChanges(currentSettings, validation.settings) : [],
+    settings: validation.settings
+  };
+}
+
+export function importPortableTeletonSettings(payload, options = {}) {
+  const preview = previewPortableTeletonSettingsImport(payload, options);
+
+  if (!preview.valid) {
+    throw new Error(preview.errors.join(' '));
+  }
+
+  return preview.settings;
 }
 
 export function serializeTeletonSettings(input = {}) {

--- a/test/agent-settings-view.test.mjs
+++ b/test/agent-settings-view.test.mjs
@@ -74,3 +74,46 @@ test('agent settings view activates local mode without cloud privacy consent', (
   assert.equal(state.activation.pending, false);
   assert.deepEqual(AGENT_PRIVACY_IMPACT_MODES, ['cloud', 'hybrid']);
 });
+
+test('agent settings view previews portable imports before applying agent changes', () => {
+  const view = createAgentSettingsView({
+    initialSettings: {
+      mode: 'local',
+      model: { provider: 'local', modelId: 'teleton-local-small' },
+      maxAutonomousActionsPerHour: 2
+    }
+  });
+  const exported = view.exportPortableSettings();
+
+  assert.equal(exported.kind, 'teleton.agent.settings.export');
+  assert.equal(exported.settings.mode, 'local');
+
+  const preview = view.previewImport({
+    ...exported,
+    settings: {
+      ...exported.settings,
+      model: { provider: 'openai', modelId: 'gpt-4.1-mini' },
+      maxAutonomousActionsPerHour: 9,
+      memory: { facts: ['private local memory must not import'] },
+      token: 'raw-token'
+    }
+  });
+
+  assert.equal(preview.valid, true);
+  assert.deepEqual(preview.excludedFields, ['memory', 'token', 'apiKey', 'secret']);
+  assert.deepEqual(preview.changes.map((change) => change.path), [
+    'model.provider',
+    'model.modelId',
+    'maxAutonomousActionsPerHour'
+  ]);
+  assert.equal(view.getState().settings.maxAutonomousActionsPerHour, 2);
+
+  const state = view.applyImport(preview);
+  assert.equal(state.settings.model.provider, 'openai');
+  assert.equal(state.settings.maxAutonomousActionsPerHour, 9);
+
+  assert.throws(
+    () => view.previewImport({ kind: 'teleton.agent.settings.export', schemaVersion: 999, settings: {} }),
+    /newer than this client supports/
+  );
+});

--- a/test/settings-model.test.mjs
+++ b/test/settings-model.test.mjs
@@ -7,7 +7,10 @@ import {
   TELETON_SETTINGS_SCHEMA,
   createPlatformSettings,
   createTeletonSettings,
+  exportPortableTeletonSettings,
+  importPortableTeletonSettings,
   migrateTeletonSettings,
+  previewPortableTeletonSettingsImport,
   validateTeletonSettings
 } from '../src/foundation/settings-model.mjs';
 
@@ -123,6 +126,112 @@ test('settings migration upgrades legacy payloads and rejects unsupported future
   assert.equal(validateTeletonSettings(migrated).valid, true);
 
   const future = validateTeletonSettings({ schemaVersion: SETTINGS_SCHEMA_VERSION + 1 });
+  assert.equal(future.valid, false);
+  assert.match(future.errors.join('\n'), /newer than this client supports/);
+});
+
+test('portable settings export excludes local secrets and private agent memory fields', () => {
+  const settings = createTeletonSettings({
+    language: 'en-US',
+    theme: 'dark',
+    agent: {
+      mode: 'local',
+      model: { provider: 'local', modelId: 'teleton-local-small' },
+      requireConfirmation: false,
+      maxAutonomousActionsPerHour: 6
+    },
+    proxy: {
+      enabled: true,
+      activeProxyId: 'office',
+      entries: [
+        {
+          id: 'office',
+          protocol: 'mtproto',
+          host: 'proxy.example',
+          port: 443,
+          secretRef: 'keychain:teleton.proxy.office'
+        }
+      ]
+    },
+    security: {
+      requireDeviceLock: true,
+      lockAfterMinutes: 10,
+      agentMemoryKeyRef: 'keychain:teleton.agentMemory.desktop.v1',
+      secretRefs: {
+        cloudAgentToken: 'keychain:teleton.agent.cloud',
+        telegramApiHash: 'env:TELEGRAM_API_HASH'
+      }
+    }
+  });
+
+  const exported = exportPortableTeletonSettings(settings);
+  const serialized = JSON.stringify(exported);
+
+  assert.equal(exported.kind, 'teleton.settings.export');
+  assert.equal(exported.schemaVersion, SETTINGS_SCHEMA_VERSION);
+  assert.equal(exported.settings.agent.mode, 'local');
+  assert.equal(exported.settings.proxy.entries[0].secretRef, undefined);
+  assert.equal(exported.settings.security.agentMemoryKeyRef, undefined);
+  assert.deepEqual(exported.settings.security.secretRefs, undefined);
+  assert.doesNotMatch(serialized, /cloudAgentToken|telegramApiHash|keychain:|env:TELEGRAM_API_HASH/);
+  assert.equal(exported.settings.agent.memory, undefined);
+  assert.equal(exported.settings.security.agentMemoryKeyRef, undefined);
+});
+
+test('portable settings import validates version and previews changes before apply', () => {
+  const current = createTeletonSettings({
+    language: 'en-US',
+    theme: 'light',
+    agent: { mode: 'local', maxAutonomousActionsPerHour: 2 },
+    security: {
+      requireDeviceLock: true,
+      lockAfterMinutes: 15,
+      agentMemoryKeyRef: 'keychain:teleton.agentMemory.desktop.v1',
+      secretRefs: { cloudAgentToken: 'keychain:teleton.agent.cloud' }
+    }
+  });
+  const exported = exportPortableTeletonSettings({
+    ...current,
+    language: 'ru',
+    theme: 'dark',
+    agent: { mode: 'local', maxAutonomousActionsPerHour: 8 },
+    security: { ...current.security, lockAfterMinutes: 30 }
+  });
+
+  const preview = previewPortableTeletonSettingsImport(exported, { currentSettings: current });
+
+  assert.equal(preview.valid, true);
+  assert.equal(preview.schemaVersion, SETTINGS_SCHEMA_VERSION);
+  assert.deepEqual(preview.excludedFields, [
+    'proxy.entries[].secretRef',
+    'proxy.entries[].usernameRef',
+    'proxy.entries[].passwordRef',
+    'security.agentMemoryKeyRef',
+    'security.secretRefs',
+    'agent.memory'
+  ]);
+  assert.deepEqual(preview.changes.map((change) => change.path), [
+    'language',
+    'theme',
+    'agent.maxAutonomousActionsPerHour',
+    'security.lockAfterMinutes'
+  ]);
+  assert.equal(preview.settings.security.agentMemoryKeyRef, 'keychain:teleton.agentMemory.desktop.v1');
+  assert.deepEqual(preview.settings.security.secretRefs, { cloudAgentToken: 'keychain:teleton.agent.cloud' });
+
+  const imported = importPortableTeletonSettings(exported, { currentSettings: current });
+  assert.equal(imported.language, 'ru');
+  assert.equal(imported.security.agentMemoryKeyRef, 'keychain:teleton.agentMemory.desktop.v1');
+
+  const malformed = previewPortableTeletonSettingsImport({ schemaVersion: SETTINGS_SCHEMA_VERSION, settings: 'bad' });
+  assert.equal(malformed.valid, false);
+  assert.match(malformed.errors.join('\n'), /settings must be an object/);
+
+  const future = previewPortableTeletonSettingsImport({
+    kind: 'teleton.settings.export',
+    schemaVersion: SETTINGS_SCHEMA_VERSION + 1,
+    settings: {}
+  });
   assert.equal(future.valid, false);
   assert.match(future.errors.join('\n'), /newer than this client supports/);
 });


### PR DESCRIPTION
## Summary\n- Add portable Teleton settings export/import helpers with schema validation and change previews.\n- Redact proxy secret references, security secret refs, and agent memory key fields from portable exports.\n- Add agent settings view export, preview, and apply workflow so callers can inspect imported changes before applying them.\n\nFixes #48\n\n## Tests\n- npm test


Fixes #48