### PR TITLE
Add reversible agent action history

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-26T14:21:36.869Z for PR creation at branch issue-50-4b2bdee9d210 for issue https://github.com/xlabtg/Teleton-Client/issues/50

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-26T14:21:36.869Z for PR creation at branch issue-50-4b2bdee9d210 for issue https://github.com/xlabtg/Teleton-Client/issues/50
+# Updated: 2026-04-26T14:33:12.552Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-26T14:21:36.869Z for PR creation at branch issue-50-4b2bdee9d210 for issue https://github.com/xlabtg/Teleton-Client/issues/50
-# Updated: 2026-04-26T14:33:12.552Z

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repository is in the foundation phase. The current implementation establish
 - Baseline TDLib client adapter contract with mock-backed tests.
 - Local Teleton Agent runtime supervisor contract with mock lifecycle tests for start, stop, health, resource monitoring, and logs.
 - Teleton Agent action notification contract for proposals, starts, completions, approval-required states, and failures with settings-aware delivery and redacted lock-screen text.
+- Teleton Agent action history contract for redacted action records, retention filtering, rollback eligibility, and irreversible action markers.
 - Teleton Agent plugin registry contract with manifest permissions, enable/disable/list/health bridge flows, and lifecycle permission gates.
 - Local Teleton Agent memory encryption contract using platform secure storage key providers, AES-256-GCM payloads, migration, missing-key, locked-store, and key-rotation tests.
 - CI workflow for foundation checks.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -26,6 +26,7 @@ Teleton Client is planned as a layered client where protocol, automation, wallet
 - Local Teleton Agent startup is represented by the `src/foundation/agent-runtime-supervisor.mjs` lifecycle boundary. Platform wrappers supply start, stop, health, resource, and log hooks; the shared supervisor keeps the default runtime local and never requires cloud credentials for startup.
 - Teleton Agent UI communication is represented by the `src/foundation/agent-ipc-bridge.mjs` contract. It uses versioned IPC envelopes for request, event, response, error, and cancellation flows; UI layers receive incoming message hooks and can distinguish informational events from confirmation-required action proposals.
 - Teleton Agent action notifications are represented by the `src/foundation/agent-action-notifications.mjs` contract. It converts action lifecycle IPC events into UI and platform notification payloads, always surfaces approval-required actions, filters informational updates through notification settings, and uses redacted lock-screen copy that does not include private message content.
+- Teleton Agent action history is represented by the `src/foundation/agent-action-history.mjs` contract. It stores redacted action records with status, actor, and timestamp fields, filters records by a local retention window, exposes rollback requests only while rollback metadata remains eligible, and marks irreversible proposals before execution.
 - Teleton Agent plugins are represented by the `src/foundation/agent-plugin-registry.mjs` contract. Plugins declare permissions, lifecycle defaults, and IPC compatibility before they can be enabled. Disabled plugins cannot receive events or perform actions, and enable, disable, list, and health-check flows are routed through the agent bridge.
 - Local Teleton Agent memory is represented by the `src/foundation/agent-memory-store.mjs` contract. It encrypts memory snapshots, vector index payloads, and local credential references with AES-256-GCM while platform wrappers keep the raw data key in OS secure storage providers such as Keychain or Keystore.
 - TON signing requires user confirmation and platform secure storage or wallet-provider approval.
@@ -56,6 +57,12 @@ UI-facing agent events are classified by confirmation behavior. Informational up
 The shared agent action notification boundary maps `agent.action.proposed`, `agent.action.started`, `agent.action.completed`, and task update events into normalized notification payloads for UI surfaces and platform notification adapters. Approval-required actions use critical priority and remain visible even when informational notifications are disabled, because they block agent progress until the user responds.
 
 Informational start, completion, and failure notifications respect the shared notification settings, including disabled notifications and mentions-only filtering. Notification bodies use action labels only, while lock-screen text and serialized payloads remove private message text, chat names, sender names, prompts, and context fields before dispatch.
+
+## Agent Action History
+
+The shared action history boundary records proposed, started, completed, failed, cancelled, and rolled-back agent actions with normalized status, actor, timestamp, action label, and redacted payload metadata. The default retention window is 30 days, and platform storage adapters can prune older records before presenting history views.
+
+Rollback metadata is explicit. Reversible actions declare a direct or compensating rollback action, sanitized rollback payload, and optional expiry timestamp. Rollback requests are exposed only while that metadata remains eligible. Irreversible proposals carry an ineligible rollback marker, a human-readable reason, and a confirmation warning before execution so UI shells can distinguish actions that cannot be compensated later.
 
 ## Agent Plugin System
 

--- a/scripts/validate-foundation.mjs
+++ b/scripts/validate-foundation.mjs
@@ -27,6 +27,8 @@ const requiredFiles = [
   'docs/tdlib-adapter.md',
   'src/foundation/agent-runtime-supervisor.mjs',
   'test/agent-runtime-supervisor.test.mjs',
+  'src/foundation/agent-action-history.mjs',
+  'test/agent-action-history.test.mjs',
   'src/foundation/agent-plugin-registry.mjs',
   'test/agent-plugin-registry.test.mjs'
 ];

--- a/src/foundation/agent-action-history.mjs
+++ b/src/foundation/agent-action-history.mjs
@@ -1,0 +1,322 @@
+export const AGENT_ACTION_HISTORY_RETENTION_DAYS = 30;
+
+export const AGENT_ACTION_STATUSES = Object.freeze(['proposed', 'started', 'completed', 'failed', 'cancelled', 'rolledBack']);
+export const AGENT_ACTION_ACTOR_TYPES = Object.freeze(['agent', 'user', 'plugin', 'system']);
+export const AGENT_ACTION_ROLLBACK_TYPES = Object.freeze(['none', 'direct', 'compensating-action']);
+
+const MILLIS_PER_DAY = 24 * 60 * 60 * 1000;
+
+const PRIVATE_PAYLOAD_FIELDS = new Set([
+  'message',
+  'messageText',
+  'text',
+  'content',
+  'body',
+  'chatTitle',
+  'chatName',
+  'senderName',
+  'recipientName',
+  'prompt',
+  'context'
+]);
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function deepFreeze(value) {
+  if (!isPlainObject(value) && !Array.isArray(value)) {
+    return value;
+  }
+
+  Object.freeze(value);
+
+  for (const fieldValue of Object.values(value)) {
+    deepFreeze(fieldValue);
+  }
+
+  return value;
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeId(value, fieldName) {
+  const id = String(value ?? '').trim();
+
+  if (!id) {
+    throw new Error(`${fieldName} must be a non-empty string.`);
+  }
+
+  return id;
+}
+
+function normalizeOptionalLabel(value, fallback) {
+  const label = String(value ?? '').trim();
+  return label || fallback;
+}
+
+function normalizeTimestamp(value, fieldName = 'Agent action history timestamp') {
+  if (value === undefined) {
+    return new Date().toISOString();
+  }
+
+  const timestamp = String(value).trim();
+  if (!timestamp || Number.isNaN(Date.parse(timestamp))) {
+    throw new Error(`${fieldName} must be an ISO-compatible date string.`);
+  }
+
+  return timestamp;
+}
+
+function normalizeOptionalTimestamp(value, fieldName) {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  return normalizeTimestamp(value, fieldName);
+}
+
+function normalizeStatus(value) {
+  const status = String(value ?? 'proposed').trim();
+
+  if (!AGENT_ACTION_STATUSES.includes(status)) {
+    throw new Error(`Unsupported agent action status: ${value}`);
+  }
+
+  return status;
+}
+
+function normalizeActor(input = {}) {
+  if (!isPlainObject(input)) {
+    throw new Error('Agent action actor must be an object.');
+  }
+
+  const type = String(input.type ?? 'agent').trim();
+  if (!AGENT_ACTION_ACTOR_TYPES.includes(type)) {
+    throw new Error(`Unsupported agent action actor type: ${input.type}`);
+  }
+
+  return Object.freeze({
+    id: normalizeId(input.id ?? type, 'Agent action actor id'),
+    type,
+    displayName: input.displayName === undefined ? null : normalizeId(input.displayName, 'Agent action actor displayName')
+  });
+}
+
+function redactPayload(value) {
+  if (!isPlainObject(value)) {
+    return {};
+  }
+
+  const redacted = {};
+
+  for (const [key, fieldValue] of Object.entries(value)) {
+    if (PRIVATE_PAYLOAD_FIELDS.has(key)) {
+      continue;
+    }
+
+    if (isPlainObject(fieldValue)) {
+      redacted[key] = redactPayload(fieldValue);
+    } else if (Array.isArray(fieldValue)) {
+      redacted[key] = fieldValue.map((item) => (isPlainObject(item) ? redactPayload(item) : item));
+    } else {
+      redacted[key] = fieldValue;
+    }
+  }
+
+  return redacted;
+}
+
+function rollbackExpired(expiresAt, now) {
+  return expiresAt !== null && Date.parse(expiresAt) <= Date.parse(now);
+}
+
+export function createRollbackMetadata(input = {}, options = {}) {
+  if (!isPlainObject(input)) {
+    throw new Error('Agent action rollback metadata must be an object.');
+  }
+
+  const now = normalizeTimestamp(options.now ?? new Date().toISOString());
+  const type = String(input.type ?? (input.action ? 'compensating-action' : 'none')).trim();
+
+  if (!AGENT_ACTION_ROLLBACK_TYPES.includes(type)) {
+    throw new Error(`Unsupported agent action rollback type: ${input.type}`);
+  }
+
+  const expiresAt = normalizeOptionalTimestamp(input.expiresAt, 'Agent action rollback expiresAt');
+  const action = input.action === undefined || input.action === null ? null : normalizeId(input.action, 'Agent action rollback action');
+  const baseEligible = type !== 'none' && action !== null;
+  const expired = rollbackExpired(expiresAt, now);
+  const explicitReason = input.reason === undefined ? null : normalizeId(input.reason, 'Agent action rollback reason');
+  const reason = explicitReason ?? (baseEligible && expired ? 'Rollback window expired.' : null);
+
+  return Object.freeze({
+    type,
+    eligible: baseEligible && !expired,
+    action,
+    actionLabel: action === null ? null : normalizeOptionalLabel(input.actionLabel, action),
+    expiresAt,
+    reason,
+    payload: deepFreeze(redactPayload(input.payload))
+  });
+}
+
+function rollbackFromAction(input, now) {
+  if (isPlainObject(input.rollback)) {
+    return createRollbackMetadata(input.rollback, { now });
+  }
+
+  if (input.reversibility === 'irreversible') {
+    return createRollbackMetadata(
+      {
+        type: 'none',
+        reason: input.irreversibleReason ?? 'Action cannot be rolled back.'
+      },
+      { now }
+    );
+  }
+
+  return createRollbackMetadata({ type: 'none' }, { now });
+}
+
+export function createAgentActionRecord(input = {}, options = {}) {
+  if (!isPlainObject(input)) {
+    throw new Error('Agent action history record must be an object.');
+  }
+
+  const now = normalizeTimestamp(options.now ?? input.timestamp ?? new Date().toISOString());
+  const id = normalizeId(input.id, 'Agent action history record id');
+  const action = normalizeId(input.action, 'Agent action history action');
+  const status = normalizeStatus(input.status);
+  const rollback = rollbackFromAction(input, now);
+  const requiresIrreversibleConfirmation = status === 'proposed' && rollback.eligible === false && rollback.reason !== null;
+
+  return Object.freeze({
+    id,
+    action,
+    actionLabel: normalizeOptionalLabel(input.actionLabel, action),
+    status,
+    actor: normalizeActor(input.actor),
+    timestamp: normalizeTimestamp(input.timestamp ?? now),
+    startedAt: normalizeOptionalTimestamp(input.startedAt, 'Agent action startedAt'),
+    completedAt: normalizeOptionalTimestamp(input.completedAt, 'Agent action completedAt'),
+    payload: deepFreeze(redactPayload(input.payload)),
+    rollback,
+    requiresIrreversibleConfirmation,
+    warning: requiresIrreversibleConfirmation ? `${normalizeOptionalLabel(input.actionLabel, action)} cannot be rolled back.` : null
+  });
+}
+
+function recordFromEvent(event, now) {
+  if (!isPlainObject(event) || event.kind !== 'event') {
+    throw new Error('Agent action history preview requires an IPC event envelope.');
+  }
+
+  return createAgentActionRecord(
+    {
+      id: event.id,
+      action: event.payload?.action,
+      actionLabel: event.payload?.actionLabel,
+      actor: { id: event.source, type: event.source === 'agent' ? 'agent' : 'system' },
+      status: event.eventType === 'agent.action.started' ? 'started' : 'proposed',
+      timestamp: event.timestamp,
+      payload: event.payload,
+      rollback: event.payload?.rollback,
+      reversibility: event.payload?.reversibility,
+      irreversibleReason: event.payload?.irreversibleReason
+    },
+    { now }
+  );
+}
+
+function retentionCutoff(now, retentionDays) {
+  return Date.parse(now) - retentionDays * MILLIS_PER_DAY;
+}
+
+export function createAgentActionHistoryStore(options = {}) {
+  const retentionDays = Number.isInteger(options.retentionDays)
+    ? options.retentionDays
+    : AGENT_ACTION_HISTORY_RETENTION_DAYS;
+
+  if (retentionDays < 1) {
+    throw new Error('Agent action history retentionDays must be a positive integer.');
+  }
+
+  const now = () => normalizeTimestamp(options.now?.() ?? new Date().toISOString());
+  const records = new Map();
+
+  function pruneExpired() {
+    const cutoff = retentionCutoff(now(), retentionDays);
+
+    for (const [id, record] of records) {
+      if (Date.parse(record.timestamp) < cutoff) {
+        records.delete(id);
+      }
+    }
+  }
+
+  function cloneRecord(record) {
+    return deepFreeze(clone(record));
+  }
+
+  return Object.freeze({
+    recordAction(input) {
+      pruneExpired();
+      const record = createAgentActionRecord(input, { now: now() });
+      records.set(record.id, record);
+      pruneExpired();
+      return cloneRecord(record);
+    },
+    previewAction(event) {
+      return recordFromEvent(event, now());
+    },
+    listRecords(filters = {}) {
+      pruneExpired();
+      let values = Array.from(records.values()).sort((left, right) => Date.parse(right.timestamp) - Date.parse(left.timestamp));
+
+      if (filters.status !== undefined) {
+        const status = normalizeStatus(filters.status);
+        values = values.filter((record) => record.status === status);
+      }
+
+      if (filters.actorId !== undefined) {
+        const actorId = normalizeId(filters.actorId, 'Agent action history actor filter');
+        values = values.filter((record) => record.actor.id === actorId);
+      }
+
+      if (filters.rollbackEligible === true) {
+        values = values.filter((record) => record.rollback.eligible === true);
+      }
+
+      return values.map(cloneRecord);
+    },
+    createRollbackRequest(recordId, payload = {}) {
+      pruneExpired();
+      const id = normalizeId(recordId, 'Agent action rollback record id');
+      const record = records.get(id);
+
+      if (!record) {
+        throw new Error(`Unknown agent action history record: ${id}`);
+      }
+
+      if (!record.rollback.eligible || !record.rollback.action) {
+        throw new Error(`Agent action history record ${id} is not rollback eligible.`);
+      }
+
+      return Object.freeze({
+        action: record.rollback.action,
+        actionLabel: record.rollback.actionLabel,
+        payload: deepFreeze({
+          ...clone(record.rollback.payload),
+          ...redactPayload(payload),
+          rollbackOf: record.id
+        })
+      });
+    },
+    retentionDays() {
+      return retentionDays;
+    }
+  });
+}

--- a/test/agent-action-history.test.mjs
+++ b/test/agent-action-history.test.mjs
@@ -1,0 +1,135 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  AGENT_ACTION_HISTORY_RETENTION_DAYS,
+  createAgentActionHistoryStore,
+  createAgentActionRecord,
+  createRollbackMetadata
+} from '../src/foundation/agent-action-history.mjs';
+import { createAgentIpcEnvelope } from '../src/foundation/agent-ipc-bridge.mjs';
+
+test('agent action history records status, actor, timestamp, and redacted payloads', () => {
+  const record = createAgentActionRecord({
+    id: 'action-1',
+    action: 'sendMessage',
+    actionLabel: 'Send message',
+    actor: { id: 'agent.local', type: 'agent', displayName: 'Teleton Agent' },
+    status: 'completed',
+    timestamp: '2026-04-26T10:00:00.000Z',
+    completedAt: '2026-04-26T10:00:05.000Z',
+    payload: {
+      chatId: 42,
+      messageText: 'private body',
+      chatTitle: 'Private chat',
+      nested: { prompt: 'secret prompt', route: 'local' }
+    }
+  });
+
+  assert.equal(record.id, 'action-1');
+  assert.equal(record.status, 'completed');
+  assert.equal(record.actor.id, 'agent.local');
+  assert.equal(record.timestamp, '2026-04-26T10:00:00.000Z');
+  assert.equal(record.completedAt, '2026-04-26T10:00:05.000Z');
+  assert.equal(record.payload.chatId, 42);
+  assert.equal(record.payload.nested.route, 'local');
+  assert.doesNotMatch(JSON.stringify(record), /private body|Private chat|secret prompt/);
+});
+
+test('agent action history filters records by retention and exposes rollback eligibility', () => {
+  const store = createAgentActionHistoryStore({
+    now: () => '2026-04-26T12:00:00.000Z',
+    retentionDays: 7
+  });
+
+  store.recordAction({
+    id: 'old-action',
+    action: 'sendMessage',
+    actor: { id: 'agent.local', type: 'agent' },
+    status: 'completed',
+    timestamp: '2026-04-01T12:00:00.000Z',
+    rollback: createRollbackMetadata({
+      type: 'compensating-action',
+      action: 'deleteMessage',
+      expiresAt: '2026-04-08T12:00:00.000Z'
+    })
+  });
+
+  const reversible = store.recordAction({
+    id: 'recent-action',
+    action: 'sendMessage',
+    actor: { id: 'agent.local', type: 'agent' },
+    status: 'completed',
+    timestamp: '2026-04-26T11:00:00.000Z',
+    rollback: {
+      type: 'compensating-action',
+      action: 'deleteMessage',
+      actionLabel: 'Delete sent message',
+      expiresAt: '2026-04-27T11:00:00.000Z',
+      payload: { messageId: 99, messageText: 'private rollback body' }
+    }
+  });
+
+  assert.equal(AGENT_ACTION_HISTORY_RETENTION_DAYS, 30);
+  assert.equal(reversible.rollback.eligible, true);
+  assert.equal(reversible.rollback.action, 'deleteMessage');
+  assert.equal(reversible.rollback.payload.messageId, 99);
+  assert.doesNotMatch(JSON.stringify(reversible.rollback), /private rollback body/);
+
+  assert.deepEqual(store.listRecords().map((record) => record.id), ['recent-action']);
+  assert.deepEqual(store.listRecords({ rollbackEligible: true }).map((record) => record.id), ['recent-action']);
+
+  const rollbackRequest = store.createRollbackRequest('recent-action', { requestedBy: 'user:42' });
+  assert.equal(rollbackRequest.action, 'deleteMessage');
+  assert.equal(rollbackRequest.payload.rollbackOf, 'recent-action');
+  assert.equal(rollbackRequest.payload.requestedBy, 'user:42');
+});
+
+test('irreversible agent actions are clearly marked before execution', () => {
+  const proposed = createAgentIpcEnvelope({
+    id: 'proposal-1',
+    kind: 'event',
+    source: 'agent',
+    target: 'ui',
+    eventType: 'agent.action.proposed',
+    timestamp: '2026-04-26T12:00:00.000Z',
+    payload: {
+      action: 'deleteMessage',
+      actionLabel: 'Delete message',
+      reversibility: 'irreversible',
+      irreversibleReason: 'Telegram does not expose message restore after deletion.',
+      messageText: 'private text'
+    }
+  });
+
+  const store = createAgentActionHistoryStore({ now: () => '2026-04-26T12:00:01.000Z' });
+  const marker = store.previewAction(proposed);
+
+  assert.equal(marker.id, 'proposal-1');
+  assert.equal(marker.status, 'proposed');
+  assert.equal(marker.rollback.eligible, false);
+  assert.equal(marker.rollback.reason, 'Telegram does not expose message restore after deletion.');
+  assert.equal(marker.requiresIrreversibleConfirmation, true);
+  assert.match(marker.warning, /cannot be rolled back/i);
+  assert.doesNotMatch(JSON.stringify(marker), /private text/);
+});
+
+test('expired rollback metadata is retained as ineligible until action history retention removes the record', () => {
+  const store = createAgentActionHistoryStore({ now: () => '2026-04-26T12:00:00.000Z' });
+  const record = store.recordAction({
+    id: 'expired-rollback',
+    action: 'editMessage',
+    actor: { id: 'agent.local', type: 'agent' },
+    status: 'completed',
+    timestamp: '2026-04-26T10:00:00.000Z',
+    rollback: {
+      type: 'direct',
+      action: 'restoreMessage',
+      expiresAt: '2026-04-26T11:00:00.000Z'
+    }
+  });
+
+  assert.equal(record.rollback.eligible, false);
+  assert.equal(record.rollback.reason, 'Rollback window expired.');
+  assert.throws(() => store.createRollbackRequest('expired-rollback'), /not rollback eligible/);
+});

--- a/test/foundation.test.mjs
+++ b/test/foundation.test.mjs
@@ -289,6 +289,37 @@ test('agent action notifications redact private content and respect settings', a
   assert.match(architecture, /lock-screen/i);
 });
 
+test('agent action history records redacted rollback-aware action records', async () => {
+  const { AGENT_ACTION_HISTORY_RETENTION_DAYS, createAgentActionHistoryStore } = await import(
+    '../src/foundation/agent-action-history.mjs'
+  );
+  const architecture = await readFile(pathFor('docs/architecture.md'), 'utf8');
+
+  const store = createAgentActionHistoryStore({ now: () => '2026-04-26T12:00:00.000Z' });
+  const record = store.recordAction({
+    id: 'history-1',
+    action: 'sendMessage',
+    actionLabel: 'Send message',
+    actor: { id: 'agent.local', type: 'agent' },
+    status: 'completed',
+    timestamp: '2026-04-26T11:00:00.000Z',
+    payload: { messageText: 'private body', chatId: 42 },
+    rollback: {
+      type: 'compensating-action',
+      action: 'deleteMessage',
+      expiresAt: '2026-04-27T11:00:00.000Z'
+    }
+  });
+
+  assert.equal(AGENT_ACTION_HISTORY_RETENTION_DAYS, 30);
+  assert.equal(record.status, 'completed');
+  assert.equal(record.actor.id, 'agent.local');
+  assert.equal(record.rollback.eligible, true);
+  assert.doesNotMatch(JSON.stringify(record), /private body/);
+  assert.match(architecture, /Agent Action History/i);
+  assert.match(architecture, /irreversible proposals/i);
+});
+
 test('agent plugin registry requires permissions and blocks disabled plugins', async () => {
   const { createAgentPluginRegistry, createMockAgentPluginBridge } = await import(
     '../src/foundation/agent-plugin-registry.mjs'


### PR DESCRIPTION
## Summary
- Adds a shared Teleton Agent action history foundation contract for status, actor, timestamp, redacted payload, retention, and rollback metadata.
- Exposes rollback request creation only while direct or compensating rollback metadata is eligible, including expiry handling.
- Marks irreversible action proposals with a confirmation warning and documents the action history boundary.

## Reproduction / Verification
- Added `test/agent-action-history.test.mjs` to cover redacted history records, retention filtering, rollback eligibility, expired rollback windows, and irreversible pre-execution markers.
- Extended `test/foundation.test.mjs` and `scripts/validate-foundation.mjs` so action history remains part of the required foundation surface.

## Local Checks
- `npm test`
- `npm run validate:foundation`
- `npm run validate:release`
- `npm run decompose:dry-run`

Fixes #51
