### PR TITLE
[030] Connect TON SDK adapter for basic wallet operations

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-26T14:21:36.869Z for PR creation at branch issue-50-4b2bdee9d210 for issue https://github.com/xlabtg/Teleton-Client/issues/50
+# Updated: 2026-04-26T14:42:41.679Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-26T14:21:36.869Z for PR creation at branch issue-50-4b2bdee9d210 for issue https://github.com/xlabtg/Teleton-Client/issues/50
-# Updated: 2026-04-26T14:42:41.679Z

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository is in the foundation phase. The current implementation establish
 - Local proxy usage statistics for attempts, successes, failures, latency, and last-used time, stored separately from proxy secrets.
 - Optional public MTProto proxy catalog metadata model that stays disabled by default and requires source freshness plus human review metadata before release.
 - Baseline TDLib client adapter contract with mock-backed tests.
+- TON wallet adapter contract for balance lookup, receive address display, transfer draft preparation, and status checks without plaintext private keys.
 - Local Teleton Agent runtime supervisor contract with mock lifecycle tests for start, stop, health, resource monitoring, and logs.
 - Teleton Agent action notification contract for proposals, starts, completions, approval-required states, and failures with settings-aware delivery and redacted lock-screen text.
 - Teleton Agent action history contract for redacted action records, retention filtering, rollback eligibility, and irreversible action markers.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,7 +29,8 @@ Teleton Client is planned as a layered client where protocol, automation, wallet
 - Teleton Agent action history is represented by the `src/foundation/agent-action-history.mjs` contract. It stores redacted action records with status, actor, and timestamp fields, filters records by a local retention window, exposes rollback requests only while rollback metadata remains eligible, and marks irreversible proposals before execution.
 - Teleton Agent plugins are represented by the `src/foundation/agent-plugin-registry.mjs` contract. Plugins declare permissions, lifecycle defaults, and IPC compatibility before they can be enabled. Disabled plugins cannot receive events or perform actions, and enable, disable, list, and health-check flows are routed through the agent bridge.
 - Local Teleton Agent memory is represented by the `src/foundation/agent-memory-store.mjs` contract. It encrypts memory snapshots, vector index payloads, and local credential references with AES-256-GCM while platform wrappers keep the raw data key in OS secure storage providers such as Keychain or Keystore.
-- TON signing requires user confirmation and platform secure storage or wallet-provider approval.
+- TON wallet operations are represented by the `src/ton/wallet-adapter.mjs` contract. Shared callers can retrieve balance, display a receive address, prepare unsigned transfer drafts, and query transfer status while platform wrappers keep private keys behind wallet providers or secure storage references.
+- TON signing requires user confirmation and platform secure storage or wallet-provider approval. Transfer preparation validates explicit confirmation before provider calls and still returns an unsigned draft for a later signing flow.
 
 ## Local Agent Runtime
 
@@ -84,4 +85,4 @@ The view also carries model provider/model id preferences, provider configuratio
 
 ## Foundation Status
 
-This PR implements only the foundation layer, epic decomposition workflow, baseline TDLib adapter boundary, local agent runtime lifecycle contract, agent IPC bridge contract, and local agent memory encryption contract. Platform UI shells, live TDLib integration, concrete agent process packaging, concrete IPC transports, concrete secure storage bindings, and live TON operations remain tracked by the generated subtasks in `config/epic-subtasks.json`.
+This PR implements only the foundation layer, epic decomposition workflow, baseline TDLib adapter boundary, local agent runtime lifecycle contract, agent IPC bridge contract, local agent memory encryption contract, and mock-backed TON wallet adapter boundary. Platform UI shells, live TDLib integration, concrete agent process packaging, concrete IPC transports, concrete secure storage bindings, and live TON operations remain tracked by the generated subtasks in `config/epic-subtasks.json`.

--- a/src/ton/wallet-adapter.mjs
+++ b/src/ton/wallet-adapter.mjs
@@ -1,0 +1,276 @@
+export const TON_NETWORKS = Object.freeze(['mainnet', 'testnet']);
+export const TON_TRANSFER_STATUSES = Object.freeze(['draft', 'pending', 'confirmed', 'failed', 'cancelled']);
+
+const REQUIRED_IMPLEMENTATION_METHODS = ['getBalance', 'getReceiveAddress', 'prepareTransfer', 'getTransferStatus'];
+const PRIVATE_KEY_FIELDS = ['privateKey', 'private_key', 'mnemonic', 'seedPhrase', 'seed_phrase'];
+
+export class TonWalletAdapterError extends Error {
+  constructor(message, code, details = []) {
+    super(message);
+    this.name = 'TonWalletAdapterError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function adapterError(errors, code) {
+  return new TonWalletAdapterError(errors.join(' '), code, errors);
+}
+
+function normalizeNetwork(value = 'testnet') {
+  const network = String(value ?? '').trim().toLowerCase();
+
+  if (!TON_NETWORKS.includes(network)) {
+    throw new TonWalletAdapterError(`Unsupported TON network: ${value}`, 'unsupported_network');
+  }
+
+  return network;
+}
+
+function assertBridgeImplementation(implementation) {
+  if (!implementation || typeof implementation !== 'object') {
+    throw new TonWalletAdapterError('TON wallet adapter implementation must be an object.', 'invalid_implementation');
+  }
+
+  const missingMethods = REQUIRED_IMPLEMENTATION_METHODS.filter((method) => typeof implementation[method] !== 'function');
+  if (missingMethods.length > 0) {
+    throw new TonWalletAdapterError(
+      `TON wallet adapter implementation is missing methods: ${missingMethods.join(', ')}.`,
+      'invalid_implementation',
+      missingMethods
+    );
+  }
+}
+
+function collectPrivateKeyErrors(input, errors) {
+  for (const field of PRIVATE_KEY_FIELDS) {
+    if (input[field] !== undefined) {
+      errors.push(
+        `TON private keys are not accepted by the shared adapter boundary. Use a wallet provider or secure storage reference instead of ${field}.`
+      );
+    }
+  }
+}
+
+function normalizeAddress(value, label, errors) {
+  const address = String(value ?? '').trim();
+  if (!address) {
+    errors.push(`TON ${label} address is required.`);
+  }
+
+  return address;
+}
+
+function normalizeNanoTon(value, errors) {
+  let amountNanoTon = value;
+  if (typeof amountNanoTon === 'number' && Number.isSafeInteger(amountNanoTon)) {
+    amountNanoTon = BigInt(amountNanoTon);
+  }
+
+  if (typeof amountNanoTon !== 'bigint' || amountNanoTon <= 0n) {
+    errors.push('TON transfer amountNanoTon must be a positive bigint or safe integer.');
+  }
+
+  return amountNanoTon;
+}
+
+export function validateTonWalletConfig(input = {}) {
+  const errors = [];
+  collectPrivateKeyErrors(input, errors);
+
+  const address = normalizeAddress(input.address, 'wallet', errors);
+  const walletProviderRef = String(input.walletProviderRef ?? input.providerRef ?? '').trim();
+  const secureStorageRef = String(input.secureStorageRef ?? '').trim();
+  const network = normalizeNetwork(input.network ?? 'testnet');
+
+  if (!walletProviderRef && !secureStorageRef) {
+    errors.push('TON walletProviderRef or secureStorageRef is required so private keys stay outside shared settings.');
+  }
+
+  const config = {
+    address,
+    network
+  };
+
+  if (walletProviderRef) {
+    config.walletProviderRef = walletProviderRef;
+  }
+
+  if (secureStorageRef) {
+    config.secureStorageRef = secureStorageRef;
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    config
+  };
+}
+
+export function validateTonTransferRequest(input = {}, walletConfig = {}) {
+  const errors = [];
+  collectPrivateKeyErrors(input, errors);
+
+  const request = {
+    from: normalizeAddress(walletConfig.address ?? input.from, 'sender', errors),
+    to: normalizeAddress(input.to, 'recipient', errors),
+    amountNanoTon: normalizeNanoTon(input.amountNanoTon, errors)
+  };
+
+  if (input.memo !== undefined) {
+    request.memo = String(input.memo);
+  }
+
+  if (input.confirmed !== true) {
+    errors.push('TON transfer preparation requires explicit confirmation before signing.');
+  } else {
+    request.confirmed = true;
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    request
+  };
+}
+
+function validateTransferStatusId(id) {
+  const errors = [];
+  const transferId = String(id ?? '').trim();
+
+  if (!transferId) {
+    errors.push('TON transfer status id is required.');
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    transferId
+  };
+}
+
+export function createTonWalletAdapter(implementation, options = {}) {
+  assertBridgeImplementation(implementation);
+
+  const validation = validateTonWalletConfig(options);
+  if (!validation.valid) {
+    throw adapterError(validation.errors, 'invalid_wallet_config');
+  }
+
+  const walletConfig = validation.config;
+
+  return Object.freeze({
+    network: walletConfig.network,
+    async getBalance() {
+      const balance = await implementation.getBalance();
+      return {
+        address: walletConfig.address,
+        network: walletConfig.network,
+        ...balance
+      };
+    },
+    async getReceiveAddress() {
+      const receiveAddress = await implementation.getReceiveAddress();
+      return {
+        address: walletConfig.address,
+        network: walletConfig.network,
+        ...receiveAddress
+      };
+    },
+    async prepareTransfer(input = {}) {
+      const transferValidation = validateTonTransferRequest(input, walletConfig);
+      if (!transferValidation.valid) {
+        throw adapterError(transferValidation.errors, 'invalid_transfer_request');
+      }
+
+      return implementation.prepareTransfer(transferValidation.request);
+    },
+    async getTransferStatus(id) {
+      const statusValidation = validateTransferStatusId(id);
+      if (!statusValidation.valid) {
+        throw adapterError(statusValidation.errors, 'invalid_transfer_status_query');
+      }
+
+      return implementation.getTransferStatus(statusValidation.transferId);
+    }
+  });
+}
+
+function cloneValue(value) {
+  return structuredClone(value);
+}
+
+export function createMockTonWalletAdapter(seed = {}) {
+  const validation = validateTonWalletConfig({
+    address: seed.address,
+    walletProviderRef: seed.walletProviderRef ?? 'wallet:mock-ton-provider',
+    secureStorageRef: seed.secureStorageRef,
+    network: seed.network ?? 'testnet'
+  });
+
+  if (!validation.valid) {
+    throw adapterError(validation.errors, 'invalid_wallet_config');
+  }
+
+  const walletConfig = validation.config;
+  const commands = [];
+  const transferDrafts = new Map();
+  let nextDraftId = 1;
+
+  const implementation = {
+    async getBalance() {
+      commands.push({ method: 'getBalance' });
+      return {
+        balanceNanoTon: seed.balanceNanoTon ?? 0n
+      };
+    },
+    async getReceiveAddress() {
+      commands.push({ method: 'getReceiveAddress' });
+      return {
+        address: walletConfig.address
+      };
+    },
+    async prepareTransfer(request) {
+      commands.push({ method: 'prepareTransfer', request: cloneValue(request) });
+      const draft = {
+        id: `mock-ton-draft-${nextDraftId}`,
+        status: 'draft',
+        signed: false,
+        requiresSigningConfirmation: true,
+        network: walletConfig.network,
+        ...request
+      };
+      nextDraftId += 1;
+      transferDrafts.set(draft.id, draft);
+
+      return cloneValue(draft);
+    },
+    async getTransferStatus(id) {
+      commands.push({ method: 'getTransferStatus', id });
+      const draft = transferDrafts.get(id);
+      if (!draft) {
+        return {
+          id,
+          status: 'failed',
+          network: walletConfig.network
+        };
+      }
+
+      return {
+        id: draft.id,
+        status: draft.status,
+        signed: draft.signed,
+        network: draft.network
+      };
+    }
+  };
+
+  const adapter = createTonWalletAdapter(implementation, walletConfig);
+
+  return Object.freeze({
+    ...adapter,
+    getCommands() {
+      return commands.map(cloneValue);
+    }
+  });
+}

--- a/test/ton-adapter.test.mjs
+++ b/test/ton-adapter.test.mjs
@@ -1,0 +1,157 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  createMockTonWalletAdapter,
+  createTonWalletAdapter,
+  validateTonTransferRequest,
+  validateTonWalletConfig
+} from '../src/ton/wallet-adapter.mjs';
+
+test('TON wallet config rejects plaintext private keys and accepts provider references', () => {
+  const invalid = validateTonWalletConfig({
+    address: 'EQDmockWalletAddress',
+    privateKey: 'plaintext-key'
+  });
+
+  assert.equal(invalid.valid, false);
+  assert.match(invalid.errors.join('\n'), /private keys are not accepted/i);
+
+  const valid = validateTonWalletConfig({
+    address: 'EQDmockWalletAddress',
+    walletProviderRef: 'wallet:tonkeeper:test-wallet'
+  });
+
+  assert.equal(valid.valid, true);
+  assert.deepEqual(valid.config, {
+    address: 'EQDmockWalletAddress',
+    walletProviderRef: 'wallet:tonkeeper:test-wallet',
+    network: 'testnet'
+  });
+});
+
+test('mock TON adapter retrieves balance and receive address without live credentials', async () => {
+  const adapter = createMockTonWalletAdapter({
+    address: 'EQDmockWalletAddress',
+    walletProviderRef: 'wallet:tonkeeper:test-wallet',
+    balanceNanoTon: 1250000000n
+  });
+
+  assert.equal(adapter.network, 'testnet');
+  assert.deepEqual(await adapter.getReceiveAddress(), {
+    address: 'EQDmockWalletAddress',
+    network: 'testnet'
+  });
+  assert.deepEqual(await adapter.getBalance(), {
+    address: 'EQDmockWalletAddress',
+    balanceNanoTon: 1250000000n,
+    network: 'testnet'
+  });
+});
+
+test('TON transfer preparation requires explicit confirmation before signing', async () => {
+  const adapter = createMockTonWalletAdapter({
+    address: 'EQDsenderAddress',
+    walletProviderRef: 'wallet:tonkeeper:test-wallet',
+    balanceNanoTon: 5000000000n
+  });
+
+  await assert.rejects(
+    () => adapter.prepareTransfer({ to: 'EQDreceiverAddress', amountNanoTon: 1000000000n }),
+    /explicit confirmation/
+  );
+
+  const draft = await adapter.prepareTransfer({
+    to: 'EQDreceiverAddress',
+    amountNanoTon: 1000000000n,
+    memo: 'agent payout',
+    confirmed: true
+  });
+
+  assert.equal(draft.status, 'draft');
+  assert.equal(draft.requiresSigningConfirmation, true);
+  assert.equal(draft.signed, false);
+  assert.equal(draft.from, 'EQDsenderAddress');
+  assert.equal(draft.to, 'EQDreceiverAddress');
+  assert.equal(draft.amountNanoTon, 1000000000n);
+  assert.deepEqual(adapter.getCommands().at(-1), {
+    method: 'prepareTransfer',
+    request: {
+      from: 'EQDsenderAddress',
+      to: 'EQDreceiverAddress',
+      amountNanoTon: 1000000000n,
+      memo: 'agent payout',
+      confirmed: true
+    }
+  });
+});
+
+test('TON adapter validates bridge inputs before provider calls', async () => {
+  const calls = [];
+  const adapter = createTonWalletAdapter(
+    {
+      async getBalance() {
+        calls.push({ method: 'getBalance' });
+        return { balanceNanoTon: 42n };
+      },
+      async getReceiveAddress() {
+        calls.push({ method: 'getReceiveAddress' });
+        return { address: 'EQDsenderAddress' };
+      },
+      async prepareTransfer(request) {
+        calls.push({ method: 'prepareTransfer', request });
+        return { id: 'draft-1', ...request, status: 'draft', signed: false, requiresSigningConfirmation: true };
+      },
+      async getTransferStatus(id) {
+        calls.push({ method: 'getTransferStatus', id });
+        return { id, status: 'draft' };
+      }
+    },
+    {
+      address: 'EQDsenderAddress',
+      walletProviderRef: 'wallet:tonkeeper:test-wallet',
+      network: 'mainnet'
+    }
+  );
+
+  await assert.rejects(() => adapter.prepareTransfer({ to: '', amountNanoTon: 1n, confirmed: true }), /recipient/);
+  await assert.rejects(
+    () => adapter.prepareTransfer({ to: 'EQDreceiverAddress', amountNanoTon: 0n, confirmed: true }),
+    /positive/
+  );
+
+  await adapter.getBalance();
+  await adapter.getReceiveAddress();
+  await adapter.prepareTransfer({ to: 'EQDreceiverAddress', amountNanoTon: 1n, confirmed: true });
+  await adapter.getTransferStatus('draft-1');
+
+  assert.deepEqual(calls, [
+    { method: 'getBalance' },
+    { method: 'getReceiveAddress' },
+    {
+      method: 'prepareTransfer',
+      request: {
+        from: 'EQDsenderAddress',
+        to: 'EQDreceiverAddress',
+        amountNanoTon: 1n,
+        confirmed: true
+      }
+    },
+    { method: 'getTransferStatus', id: 'draft-1' }
+  ]);
+});
+
+test('TON transfer validation rejects secret material in transfer requests', () => {
+  const validation = validateTonTransferRequest(
+    {
+      to: 'EQDreceiverAddress',
+      amountNanoTon: 1n,
+      confirmed: true,
+      privateKey: 'plaintext-key'
+    },
+    { address: 'EQDsenderAddress' }
+  );
+
+  assert.equal(validation.valid, false);
+  assert.match(validation.errors.join('\n'), /private keys are not accepted/i);
+});


### PR DESCRIPTION
## Summary
- Add a mock-backed TON wallet adapter boundary for balance lookup, receive address display, transfer draft preparation, and transfer status lookup.
- Validate wallet and transfer inputs so plaintext private keys, mnemonics, and seed phrases are rejected at the shared adapter boundary.
- Require explicit transfer confirmation before provider calls while keeping prepared transfers unsigned for a later signing flow.
- Document the new TON wallet boundary in the README and architecture notes.

## Tests
- `node --test test/ton-adapter.test.mjs`
- `npm test`
- `npm run validate:foundation`
- `npm run validate:release`
- `npm run decompose:dry-run`

## Reproduction
Before this change, importing `src/ton/wallet-adapter.mjs` from `test/ton-adapter.test.mjs` failed because the TON adapter boundary did not exist. The new tests cover the expected mock balance flow, receive address flow, confirmation gate, status lookup, and private key rejection.

## Risk
- Live TON SDK and wallet-provider integrations remain out of scope; platform wrappers can now implement against this shared boundary.

Fixes #15
