### PR TITLE
Integrate TON swap adapter boundary

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-26T14:49:27.303Z for PR creation at branch issue-16-a98c192f8ee7 for issue https://github.com/xlabtg/Teleton-Client/issues/16

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-26T14:49:27.303Z for PR creation at branch issue-16-a98c192f8ee7 for issue https://github.com/xlabtg/Teleton-Client/issues/16

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repository is in the foundation phase. The current implementation establish
 - Optional public MTProto proxy catalog metadata model that stays disabled by default and requires source freshness plus human review metadata before release.
 - Baseline TDLib client adapter contract with mock-backed tests.
 - TON wallet adapter contract for balance lookup, receive address display, transfer draft preparation, and status checks without plaintext private keys.
+- TON swap adapter contract for STON.fi and DeDust quote lookup plus confirmation-gated swap transaction draft preparation.
 - Local Teleton Agent runtime supervisor contract with mock lifecycle tests for start, stop, health, resource monitoring, and logs.
 - Teleton Agent action notification contract for proposals, starts, completions, approval-required states, and failures with settings-aware delivery and redacted lock-screen text.
 - Teleton Agent action history contract for redacted action records, retention filtering, rollback eligibility, and irreversible action markers.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,6 +31,7 @@ Teleton Client is planned as a layered client where protocol, automation, wallet
 - Local Teleton Agent memory is represented by the `src/foundation/agent-memory-store.mjs` contract. It encrypts memory snapshots, vector index payloads, and local credential references with AES-256-GCM while platform wrappers keep the raw data key in OS secure storage providers such as Keychain or Keystore.
 - TON wallet operations are represented by the `src/ton/wallet-adapter.mjs` contract. Shared callers can retrieve balance, display a receive address, prepare unsigned transfer drafts, and query transfer status while platform wrappers keep private keys behind wallet providers or secure storage references.
 - TON signing requires user confirmation and platform secure storage or wallet-provider approval. Transfer preparation validates explicit confirmation before provider calls and still returns an unsigned draft for a later signing flow.
+- TON swap operations are represented by the `src/ton/swap-adapter.mjs` contract. Shared callers can request STON.fi or DeDust quotes without signing, while swap transaction draft preparation requires explicit confirmation and provider errors are sanitized before they cross the shared boundary.
 
 ## Local Agent Runtime
 
@@ -85,4 +86,4 @@ The view also carries model provider/model id preferences, provider configuratio
 
 ## Foundation Status
 
-This PR implements only the foundation layer, epic decomposition workflow, baseline TDLib adapter boundary, local agent runtime lifecycle contract, agent IPC bridge contract, local agent memory encryption contract, and mock-backed TON wallet adapter boundary. Platform UI shells, live TDLib integration, concrete agent process packaging, concrete IPC transports, concrete secure storage bindings, and live TON operations remain tracked by the generated subtasks in `config/epic-subtasks.json`.
+This PR implements only the foundation layer, epic decomposition workflow, baseline TDLib adapter boundary, local agent runtime lifecycle contract, agent IPC bridge contract, local agent memory encryption contract, mock-backed TON wallet adapter boundary, and mock-backed TON swap adapter boundary. Platform UI shells, live TDLib integration, concrete agent process packaging, concrete IPC transports, concrete secure storage bindings, and live TON operations remain tracked by the generated subtasks in `config/epic-subtasks.json`.

--- a/src/ton/swap-adapter.mjs
+++ b/src/ton/swap-adapter.mjs
@@ -1,0 +1,313 @@
+import { TON_NETWORKS, validateTonWalletConfig } from './wallet-adapter.mjs';
+
+export const TON_SWAP_PROVIDERS = Object.freeze(['stonfi', 'dedust']);
+export const TON_SWAP_TRANSACTION_STATUSES = Object.freeze(['draft', 'pending', 'confirmed', 'failed', 'cancelled']);
+
+const REQUIRED_PROVIDER_METHODS = ['getQuote', 'prepareSwapTransaction'];
+const PRIVATE_KEY_FIELDS = ['privateKey', 'private_key', 'mnemonic', 'seedPhrase', 'seed_phrase'];
+const DEFAULT_SLIPPAGE_BPS = 50;
+const MAX_SLIPPAGE_BPS = 5000;
+
+export class TonSwapAdapterError extends Error {
+  constructor(message, code, details = []) {
+    super(message);
+    this.name = 'TonSwapAdapterError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function cloneValue(value) {
+  return structuredClone(value);
+}
+
+function adapterError(errors, code) {
+  return new TonSwapAdapterError(errors.join(' '), code, errors);
+}
+
+function collectPrivateKeyErrors(input, errors) {
+  for (const field of PRIVATE_KEY_FIELDS) {
+    if (input[field] !== undefined) {
+      errors.push(
+        `TON private keys are not accepted by the shared swap adapter boundary. Use a wallet provider or secure storage reference instead of ${field}.`
+      );
+    }
+  }
+}
+
+function normalizeNetwork(value = 'testnet') {
+  const network = String(value ?? '').trim().toLowerCase();
+
+  if (!TON_NETWORKS.includes(network)) {
+    throw new TonSwapAdapterError(`Unsupported TON network: ${value}`, 'unsupported_network');
+  }
+
+  return network;
+}
+
+function normalizeProvider(value, errors) {
+  const provider = String(value ?? '').trim().toLowerCase();
+
+  if (!TON_SWAP_PROVIDERS.includes(provider)) {
+    errors.push(`Unsupported TON swap provider: ${value}. Supported providers: ${TON_SWAP_PROVIDERS.join(', ')}.`);
+  }
+
+  return provider;
+}
+
+function normalizeAsset(value, label, errors) {
+  const asset = String(value ?? '').trim();
+  if (!asset) {
+    errors.push(`TON swap ${label} asset is required.`);
+  }
+
+  return asset;
+}
+
+function normalizePositiveUnits(value, fieldName, errors) {
+  let amount = value;
+  if (typeof amount === 'number' && Number.isSafeInteger(amount)) {
+    amount = BigInt(amount);
+  }
+
+  if (typeof amount !== 'bigint' || amount <= 0n) {
+    errors.push(`TON swap ${fieldName} must be a positive bigint or safe integer.`);
+  }
+
+  return amount;
+}
+
+function normalizeSlippageBps(value, errors) {
+  const slippageBps = value ?? DEFAULT_SLIPPAGE_BPS;
+
+  if (!Number.isSafeInteger(slippageBps) || slippageBps < 0 || slippageBps > MAX_SLIPPAGE_BPS) {
+    errors.push(`TON swap slippageBps must be an integer from 0 to ${MAX_SLIPPAGE_BPS}.`);
+  }
+
+  return slippageBps;
+}
+
+function normalizeQuoteId(value, errors) {
+  const quoteId = String(value ?? '').trim();
+
+  if (!quoteId) {
+    errors.push('TON swap quoteId is required.');
+  }
+
+  return quoteId;
+}
+
+function assertProviderImplementations(providers) {
+  if (!providers || typeof providers !== 'object') {
+    throw new TonSwapAdapterError('TON swap adapter providers must be an object.', 'invalid_implementation');
+  }
+
+  for (const provider of TON_SWAP_PROVIDERS) {
+    const implementation = providers[provider];
+    if (!implementation || typeof implementation !== 'object') {
+      throw new TonSwapAdapterError(`TON swap adapter is missing ${provider} provider implementation.`, 'invalid_implementation');
+    }
+
+    const missingMethods = REQUIRED_PROVIDER_METHODS.filter((method) => typeof implementation[method] !== 'function');
+    if (missingMethods.length > 0) {
+      throw new TonSwapAdapterError(
+        `TON swap ${provider} provider is missing methods: ${missingMethods.join(', ')}.`,
+        'invalid_implementation',
+        missingMethods
+      );
+    }
+  }
+}
+
+export function validateTonSwapQuoteRequest(input = {}, defaults = {}) {
+  const errors = [];
+  collectPrivateKeyErrors(input, errors);
+
+  const provider = normalizeProvider(input.provider ?? defaults.provider, errors);
+  const fromAsset = normalizeAsset(input.fromAsset, 'source', errors);
+  const toAsset = normalizeAsset(input.toAsset, 'destination', errors);
+  const amountNanoUnits = normalizePositiveUnits(input.amountNanoUnits, 'amountNanoUnits', errors);
+  const slippageBps = normalizeSlippageBps(input.slippageBps, errors);
+  const network = normalizeNetwork(input.network ?? defaults.network ?? 'testnet');
+
+  if (fromAsset && toAsset && fromAsset === toAsset) {
+    errors.push('TON swap source and destination assets must differ.');
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    request: {
+      provider,
+      fromAsset,
+      toAsset,
+      amountNanoUnits,
+      slippageBps,
+      network
+    }
+  };
+}
+
+export function validateTonSwapTransactionRequest(input = {}, walletConfig = {}) {
+  const errors = [];
+  collectPrivateKeyErrors(input, errors);
+
+  const provider = input.provider === undefined ? undefined : normalizeProvider(input.provider, errors);
+  const request = {
+    quoteId: normalizeQuoteId(input.quoteId, errors),
+    from: String(walletConfig.address ?? input.from ?? '').trim(),
+    confirmed: input.confirmed === true,
+    network: normalizeNetwork(input.network ?? walletConfig.network ?? 'testnet')
+  };
+
+  if (!request.from) {
+    errors.push('TON swap sender address is required.');
+  }
+
+  if (provider !== undefined) {
+    request.provider = provider;
+  }
+
+  if (input.confirmed !== true) {
+    errors.push('TON swap transaction preparation requires explicit confirmation before signing.');
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    request
+  };
+}
+
+export function sanitizeTonSwapProviderError(error) {
+  const rawMessage = error instanceof Error ? error.message : String(error ?? 'Unknown TON swap provider error.');
+  const message = rawMessage
+    .replace(/\b(privateKey|private_key|mnemonic|seedPhrase|seed_phrase)=[^\s]+/gi, '[redacted]')
+    .replace(/\bsecureRef=env:[^\s]+/gi, '[redacted]')
+    .replace(/\benv:[A-Z0-9_]+\b/g, '[redacted]');
+
+  return new TonSwapAdapterError(message, 'swap_provider_error');
+}
+
+async function callProvider(provider, method, request) {
+  try {
+    return await provider[method](request);
+  } catch (error) {
+    throw sanitizeTonSwapProviderError(error);
+  }
+}
+
+export function createTonSwapAdapter(providers, options = {}) {
+  assertProviderImplementations(providers);
+
+  const walletValidation = validateTonWalletConfig(options);
+  if (!walletValidation.valid) {
+    throw adapterError(walletValidation.errors, 'invalid_wallet_config');
+  }
+
+  const walletConfig = walletValidation.config;
+
+  return Object.freeze({
+    network: walletConfig.network,
+    providers: TON_SWAP_PROVIDERS,
+    async getQuote(input = {}) {
+      const quoteValidation = validateTonSwapQuoteRequest(input, { network: walletConfig.network });
+      if (!quoteValidation.valid) {
+        throw adapterError(quoteValidation.errors, 'invalid_swap_quote_request');
+      }
+
+      const quote = await callProvider(providers[quoteValidation.request.provider], 'getQuote', quoteValidation.request);
+      return {
+        provider: quoteValidation.request.provider,
+        network: walletConfig.network,
+        requiresTransactionConfirmation: false,
+        signed: false,
+        ...quote
+      };
+    },
+    async prepareSwapTransaction(input = {}) {
+      const transactionValidation = validateTonSwapTransactionRequest(input, walletConfig);
+      if (!transactionValidation.valid) {
+        throw adapterError(transactionValidation.errors, 'invalid_swap_transaction_request');
+      }
+
+      const provider = transactionValidation.request.provider ?? 'stonfi';
+      return callProvider(providers[provider], 'prepareSwapTransaction', transactionValidation.request);
+    }
+  });
+}
+
+export function createMockTonSwapAdapter(seed = {}) {
+  const walletValidation = validateTonWalletConfig({
+    address: seed.address,
+    walletProviderRef: seed.walletProviderRef ?? 'wallet:mock-ton-provider',
+    secureStorageRef: seed.secureStorageRef,
+    network: seed.network ?? 'testnet'
+  });
+
+  if (!walletValidation.valid) {
+    throw adapterError(walletValidation.errors, 'invalid_wallet_config');
+  }
+
+  const walletConfig = walletValidation.config;
+  const commands = [];
+  const quotes = new Map();
+  let nextQuoteId = 1;
+  let nextDraftId = 1;
+
+  function makeProvider(provider) {
+    return {
+      async getQuote(request) {
+        commands.push({ method: 'getQuote', request: cloneValue(request) });
+        const quote = {
+          id: `mock-${provider}-quote-${nextQuoteId}`,
+          provider,
+          network: walletConfig.network,
+          fromAsset: request.fromAsset,
+          toAsset: request.toAsset,
+          amountNanoUnits: request.amountNanoUnits,
+          expectedOutNanoUnits: request.amountNanoUnits,
+          minOutNanoUnits: request.amountNanoUnits,
+          priceImpactBps: 0,
+          expiresAt: seed.expiresAt ?? '2026-04-26T00:05:00.000Z',
+          requiresTransactionConfirmation: false,
+          signed: false
+        };
+        nextQuoteId += 1;
+        quotes.set(quote.id, quote);
+        return cloneValue(quote);
+      },
+      async prepareSwapTransaction(request) {
+        commands.push({ method: 'prepareSwapTransaction', request: cloneValue(request) });
+        const quote = quotes.get(request.quoteId);
+        const draft = {
+          id: `mock-${provider}-swap-draft-${nextDraftId}`,
+          quoteId: request.quoteId,
+          provider: quote?.provider ?? provider,
+          status: 'draft',
+          from: request.from,
+          network: walletConfig.network,
+          signed: false,
+          requiresSigningConfirmation: true
+        };
+        nextDraftId += 1;
+        return cloneValue(draft);
+      }
+    };
+  }
+
+  const adapter = createTonSwapAdapter(
+    {
+      stonfi: makeProvider('stonfi'),
+      dedust: makeProvider('dedust')
+    },
+    walletConfig
+  );
+
+  return Object.freeze({
+    ...adapter,
+    getCommands() {
+      return commands.map(cloneValue);
+    }
+  });
+}

--- a/test/ton-swap-adapter.test.mjs
+++ b/test/ton-swap-adapter.test.mjs
@@ -1,0 +1,216 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  createMockTonSwapAdapter,
+  createTonSwapAdapter,
+  sanitizeTonSwapProviderError,
+  validateTonSwapQuoteRequest,
+  validateTonSwapTransactionRequest
+} from '../src/ton/swap-adapter.mjs';
+
+test('TON swap quote validation normalizes provider, assets, and slippage without confirmation', () => {
+  const validation = validateTonSwapQuoteRequest({
+    provider: 'stonfi',
+    fromAsset: 'TON',
+    toAsset: 'USDT',
+    amountNanoUnits: 1000000000n,
+    slippageBps: 75
+  });
+
+  assert.equal(validation.valid, true);
+  assert.deepEqual(validation.request, {
+    provider: 'stonfi',
+    fromAsset: 'TON',
+    toAsset: 'USDT',
+    amountNanoUnits: 1000000000n,
+    slippageBps: 75,
+    network: 'testnet'
+  });
+});
+
+test('mock TON swap adapter exposes STON.fi and DeDust quote adapters without signing', async () => {
+  const adapter = createMockTonSwapAdapter({
+    address: 'EQDsenderAddress',
+    walletProviderRef: 'wallet:tonkeeper:test-wallet'
+  });
+
+  const stonfiQuote = await adapter.getQuote({
+    provider: 'stonfi',
+    fromAsset: 'TON',
+    toAsset: 'USDT',
+    amountNanoUnits: 1000000000n
+  });
+  const dedustQuote = await adapter.getQuote({
+    provider: 'dedust',
+    fromAsset: 'TON',
+    toAsset: 'USDT',
+    amountNanoUnits: 2000000000n
+  });
+
+  assert.equal(stonfiQuote.provider, 'stonfi');
+  assert.equal(stonfiQuote.requiresTransactionConfirmation, false);
+  assert.equal(stonfiQuote.signed, false);
+  assert.equal(dedustQuote.provider, 'dedust');
+  assert.equal(dedustQuote.requiresTransactionConfirmation, false);
+  assert.equal(dedustQuote.signed, false);
+  assert.deepEqual(
+    adapter.getCommands().map((command) => command.method),
+    ['getQuote', 'getQuote']
+  );
+});
+
+test('TON swap transaction preparation is blocked until explicit user confirmation', async () => {
+  const adapter = createMockTonSwapAdapter({
+    address: 'EQDsenderAddress',
+    walletProviderRef: 'wallet:tonkeeper:test-wallet'
+  });
+  const quote = await adapter.getQuote({
+    provider: 'stonfi',
+    fromAsset: 'TON',
+    toAsset: 'USDT',
+    amountNanoUnits: 1000000000n
+  });
+
+  await assert.rejects(() => adapter.prepareSwapTransaction({ quoteId: quote.id }), /requires explicit confirmation/);
+
+  const draft = await adapter.prepareSwapTransaction({
+    quoteId: quote.id,
+    confirmed: true
+  });
+
+  assert.equal(draft.status, 'draft');
+  assert.equal(draft.provider, 'stonfi');
+  assert.equal(draft.from, 'EQDsenderAddress');
+  assert.equal(draft.signed, false);
+  assert.equal(draft.requiresSigningConfirmation, true);
+  assert.deepEqual(adapter.getCommands().at(-1), {
+    method: 'prepareSwapTransaction',
+    request: {
+      quoteId: quote.id,
+      from: 'EQDsenderAddress',
+      confirmed: true,
+      network: 'testnet'
+    }
+  });
+});
+
+test('TON swap adapter validates requests before provider calls', async () => {
+  const calls = [];
+  const adapter = createTonSwapAdapter(
+    {
+      stonfi: {
+        async getQuote(request) {
+          calls.push({ method: 'stonfi.getQuote', request });
+          return { id: 'quote-1', provider: request.provider };
+        },
+        async prepareSwapTransaction(request) {
+          calls.push({ method: 'stonfi.prepareSwapTransaction', request });
+          return { id: 'draft-1', status: 'draft', signed: false, requiresSigningConfirmation: true };
+        }
+      },
+      dedust: {
+        async getQuote(request) {
+          calls.push({ method: 'dedust.getQuote', request });
+          return { id: 'quote-2', provider: request.provider };
+        },
+        async prepareSwapTransaction(request) {
+          calls.push({ method: 'dedust.prepareSwapTransaction', request });
+          return { id: 'draft-2', status: 'draft', signed: false, requiresSigningConfirmation: true };
+        }
+      }
+    },
+    {
+      address: 'EQDsenderAddress',
+      walletProviderRef: 'wallet:tonkeeper:test-wallet',
+      network: 'mainnet'
+    }
+  );
+
+  await assert.rejects(() => adapter.getQuote({ provider: 'unknown', fromAsset: 'TON', toAsset: 'USDT', amountNanoUnits: 1n }), /Unsupported TON swap provider/);
+  await assert.rejects(() => adapter.getQuote({ provider: 'stonfi', fromAsset: 'TON', toAsset: 'TON', amountNanoUnits: 1n }), /must differ/);
+  await assert.rejects(() => adapter.prepareSwapTransaction({ quoteId: 'quote-1', confirmed: false }), /requires explicit confirmation/);
+
+  await adapter.getQuote({ provider: 'stonfi', fromAsset: 'TON', toAsset: 'USDT', amountNanoUnits: 1n });
+  await adapter.prepareSwapTransaction({ provider: 'stonfi', quoteId: 'quote-1', confirmed: true });
+
+  assert.deepEqual(calls, [
+    {
+      method: 'stonfi.getQuote',
+      request: {
+        provider: 'stonfi',
+        fromAsset: 'TON',
+        toAsset: 'USDT',
+        amountNanoUnits: 1n,
+        slippageBps: 50,
+        network: 'mainnet'
+      }
+    },
+    {
+      method: 'stonfi.prepareSwapTransaction',
+      request: {
+        provider: 'stonfi',
+        quoteId: 'quote-1',
+        from: 'EQDsenderAddress',
+        confirmed: true,
+        network: 'mainnet'
+      }
+    }
+  ]);
+});
+
+test('TON swap provider errors are surfaced without leaking wallet secrets', async () => {
+  const adapter = createTonSwapAdapter(
+    {
+      stonfi: {
+        async getQuote() {
+          throw new Error('STON.fi timeout for privateKey=plaintext seedPhrase=words wallet env:TON_SECRET');
+        },
+        async prepareSwapTransaction() {
+          throw new Error('not used');
+        }
+      },
+      dedust: {
+        async getQuote() {
+          throw new Error('not used');
+        },
+        async prepareSwapTransaction() {
+          throw new Error('not used');
+        }
+      }
+    },
+    {
+      address: 'EQDsenderAddress',
+      walletProviderRef: 'wallet:tonkeeper:test-wallet'
+    }
+  );
+
+  await assert.rejects(
+    () => adapter.getQuote({ provider: 'stonfi', fromAsset: 'TON', toAsset: 'USDT', amountNanoUnits: 1n }),
+    (error) => {
+      assert.equal(error.code, 'swap_provider_error');
+      assert.match(error.message, /STON\.fi timeout/);
+      assert.doesNotMatch(error.message, /plaintext|words|TON_SECRET|privateKey|seedPhrase/);
+      return true;
+    }
+  );
+
+  assert.equal(
+    sanitizeTonSwapProviderError(new Error('failed with mnemonic=alpha secureRef=env:TON_SECRET')).message,
+    'failed with [redacted] [redacted]'
+  );
+});
+
+test('TON swap transaction validation rejects secret material', () => {
+  const validation = validateTonSwapTransactionRequest(
+    {
+      quoteId: 'quote-1',
+      confirmed: true,
+      privateKey: 'plaintext-key'
+    },
+    { address: 'EQDsenderAddress' }
+  );
+
+  assert.equal(validation.valid, false);
+  assert.match(validation.errors.join('\n'), /private keys are not accepted/i);
+});


### PR DESCRIPTION
## Summary
- Add a shared TON swap adapter contract for STON.fi and DeDust quote providers.
- Allow quote lookup without transaction confirmation or signing.
- Gate swap transaction draft preparation behind explicit confirmation and sanitize provider errors before surfacing them.
- Document the new swap boundary in README and architecture docs.

## Reproduction and Verification
- Reproduces issue #16 with tests that cover quote requests, STON.fi/DeDust provider routing, confirmation blocking, and provider error redaction.
- Automated test coverage: `test/ton-swap-adapter.test.mjs`.

## Validation
- `npm test`
- `npm run validate:foundation`
- `npm run validate:release`
- `npm run decompose:dry-run`

Fixes #16