### PR TITLE
Build TON transaction confirmation workflow

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-26T15:00:01.238Z for PR creation at branch issue-17-e7dc5d9607ea for issue https://github.com/xlabtg/Teleton-Client/issues/17

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-26T15:00:01.238Z for PR creation at branch issue-17-e7dc5d9607ea for issue https://github.com/xlabtg/Teleton-Client/issues/17

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repository is in the foundation phase. The current implementation establish
 - Baseline TDLib client adapter contract with mock-backed tests.
 - TON wallet adapter contract for balance lookup, receive address display, transfer draft preparation, and status checks without plaintext private keys.
 - TON swap adapter contract for STON.fi and DeDust quote lookup plus confirmation-gated swap transaction draft preparation.
+- TON transaction confirmation workflow for review details, biometric or password approval hooks, limit/risk indicators, and status history.
 - Local Teleton Agent runtime supervisor contract with mock lifecycle tests for start, stop, health, resource monitoring, and logs.
 - Teleton Agent action notification contract for proposals, starts, completions, approval-required states, and failures with settings-aware delivery and redacted lock-screen text.
 - Teleton Agent action history contract for redacted action records, retention filtering, rollback eligibility, and irreversible action markers.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,6 +32,7 @@ Teleton Client is planned as a layered client where protocol, automation, wallet
 - TON wallet operations are represented by the `src/ton/wallet-adapter.mjs` contract. Shared callers can retrieve balance, display a receive address, prepare unsigned transfer drafts, and query transfer status while platform wrappers keep private keys behind wallet providers or secure storage references.
 - TON signing requires user confirmation and platform secure storage or wallet-provider approval. Transfer preparation validates explicit confirmation before provider calls and still returns an unsigned draft for a later signing flow.
 - TON swap operations are represented by the `src/ton/swap-adapter.mjs` contract. Shared callers can request STON.fi or DeDust quotes without signing, while swap transaction draft preparation requires explicit confirmation and provider errors are sanitized before they cross the shared boundary.
+- TON transaction confirmation is represented by the `src/ton/transaction-confirmation.mjs` workflow. It builds review state with amount, recipient, network fee, provider, limit state, and risk indicators, then requires a platform biometric or password approval bridge before callers may continue to signing. The workflow records pending, approved, rejected, and failed history states for audit views.
 
 ## Local Agent Runtime
 

--- a/src/ton/transaction-confirmation.mjs
+++ b/src/ton/transaction-confirmation.mjs
@@ -1,0 +1,355 @@
+export const TON_TRANSACTION_HISTORY_STATUSES = Object.freeze(['approved', 'rejected', 'failed', 'pending']);
+export const TON_CONFIRMATION_METHODS = Object.freeze(['biometric', 'password']);
+
+const DEFAULT_LIMITS = Object.freeze({
+  perTransactionLimitNanoTon: null,
+  remainingDailyLimitNanoTon: null,
+  highFeeNanoTon: null
+});
+
+export class TonTransactionConfirmationError extends Error {
+  constructor(message, code, details = []) {
+    super(message);
+    this.name = 'TonTransactionConfirmationError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function adapterError(errors, code) {
+  return new TonTransactionConfirmationError(errors.join(' '), code, errors);
+}
+
+function normalizeId(value, label, errors) {
+  const id = String(value ?? '').trim();
+  if (!id) {
+    errors.push(`TON transaction ${label} is required.`);
+  }
+
+  return id;
+}
+
+function normalizePositiveNanoTon(value, fieldName, errors) {
+  let amount = value;
+  if (typeof amount === 'number' && Number.isSafeInteger(amount)) {
+    amount = BigInt(amount);
+  }
+
+  if (typeof amount !== 'bigint' || amount <= 0n) {
+    errors.push(`TON transaction ${fieldName} must be a positive bigint or safe integer.`);
+  }
+
+  return amount;
+}
+
+function normalizeNonNegativeNanoTon(value, fieldName, errors) {
+  let amount = value;
+  if (typeof amount === 'number' && Number.isSafeInteger(amount)) {
+    amount = BigInt(amount);
+  }
+
+  if (typeof amount !== 'bigint' || amount < 0n) {
+    errors.push(`TON transaction ${fieldName} must be a non-negative bigint or safe integer.`);
+  }
+
+  return amount;
+}
+
+function normalizeOptionalLimit(value, fieldName, errors) {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  return normalizePositiveNanoTon(value, fieldName, errors);
+}
+
+function normalizeTimestamp(value, fieldName = 'TON transaction timestamp') {
+  const timestamp = String(value ?? '').trim();
+  if (!timestamp || Number.isNaN(Date.parse(timestamp))) {
+    throw new TonTransactionConfirmationError(`${fieldName} must be an ISO-compatible date string.`, 'invalid_timestamp');
+  }
+
+  return timestamp;
+}
+
+function normalizeLimits(input = {}) {
+  const errors = [];
+  const limits = {
+    perTransactionLimitNanoTon: normalizeOptionalLimit(input.perTransactionLimitNanoTon, 'perTransactionLimitNanoTon', errors),
+    remainingDailyLimitNanoTon: normalizeOptionalLimit(input.remainingDailyLimitNanoTon, 'remainingDailyLimitNanoTon', errors),
+    highFeeNanoTon: normalizeOptionalLimit(input.highFeeNanoTon, 'highFeeNanoTon', errors)
+  };
+
+  if (errors.length > 0) {
+    throw adapterError(errors, 'invalid_transaction_limits');
+  }
+
+  return limits;
+}
+
+function createRiskIndicators(review, limits) {
+  const riskIndicators = [];
+
+  if (limits.perTransactionLimitNanoTon !== null && review.amountNanoTon > limits.perTransactionLimitNanoTon) {
+    riskIndicators.push({
+      code: 'amount_exceeds_limit',
+      severity: 'high',
+      message: 'TON transaction amount exceeds the configured per-transaction limit.'
+    });
+  }
+
+  if (limits.remainingDailyLimitNanoTon !== null && review.amountNanoTon > limits.remainingDailyLimitNanoTon) {
+    riskIndicators.push({
+      code: 'daily_limit_exceeded',
+      severity: 'high',
+      message: 'TON transaction amount exceeds the remaining daily limit.'
+    });
+  }
+
+  if (limits.highFeeNanoTon !== null && review.networkFeeNanoTon > limits.highFeeNanoTon) {
+    riskIndicators.push({
+      code: 'network_fee_high',
+      severity: 'medium',
+      message: 'TON transaction network fee is higher than the configured review threshold.'
+    });
+  }
+
+  return riskIndicators;
+}
+
+function assertApprovalBridge(approval) {
+  if (!approval || typeof approval.confirm !== 'function') {
+    throw new TonTransactionConfirmationError(
+      'TON transaction confirmation workflow requires an approval bridge with a confirm method.',
+      'invalid_approval_bridge'
+    );
+  }
+}
+
+function normalizeApprovalMethods(methods) {
+  const availableMethods = [...new Set((methods ?? []).map((method) => String(method).trim()).filter(Boolean))];
+  const unsupported = availableMethods.filter((method) => !TON_CONFIRMATION_METHODS.includes(method));
+
+  if (availableMethods.length === 0) {
+    throw new TonTransactionConfirmationError(
+      'TON transaction approval requires at least one biometric or password method.',
+      'missing_approval_method'
+    );
+  }
+
+  if (unsupported.length > 0) {
+    throw new TonTransactionConfirmationError(
+      `Unsupported TON transaction approval methods: ${unsupported.join(', ')}.`,
+      'unsupported_approval_method',
+      unsupported
+    );
+  }
+
+  return availableMethods;
+}
+
+export function validateTonTransactionReview(input = {}, limitInput = {}) {
+  const errors = [];
+  if (!isPlainObject(input)) {
+    return {
+      valid: false,
+      errors: ['TON transaction review must be an object.'],
+      review: null
+    };
+  }
+
+  const limits = normalizeLimits({ ...DEFAULT_LIMITS, ...limitInput });
+  const amountNanoTon = normalizePositiveNanoTon(input.amountNanoTon, 'amountNanoTon', errors);
+  const networkFeeNanoTon = normalizeNonNegativeNanoTon(input.networkFeeNanoTon, 'networkFeeNanoTon', errors);
+  const totalNanoTon =
+    input.totalNanoTon === undefined || input.totalNanoTon === null
+      ? typeof amountNanoTon === 'bigint' && typeof networkFeeNanoTon === 'bigint'
+        ? amountNanoTon + networkFeeNanoTon
+        : input.totalNanoTon
+      : normalizePositiveNanoTon(input.totalNanoTon, 'totalNanoTon', errors);
+
+  const review = {
+    id: normalizeId(input.id, 'id', errors),
+    amountNanoTon,
+    recipient: normalizeId(input.recipient ?? input.to, 'recipient', errors),
+    networkFeeNanoTon,
+    provider: normalizeId(input.provider, 'provider', errors),
+    totalNanoTon,
+    memo: input.memo === undefined || input.memo === null ? null : String(input.memo)
+  };
+
+  if (typeof review.totalNanoTon === 'bigint' && typeof review.amountNanoTon === 'bigint' && review.totalNanoTon < review.amountNanoTon) {
+    errors.push('TON transaction totalNanoTon cannot be less than amountNanoTon.');
+  }
+
+  if (errors.length > 0) {
+    return {
+      valid: false,
+      errors,
+      review
+    };
+  }
+
+  const limitState = {
+    perTransactionLimitNanoTon: limits.perTransactionLimitNanoTon,
+    remainingDailyLimitNanoTon: limits.remainingDailyLimitNanoTon,
+    exceedsPerTransactionLimit:
+      limits.perTransactionLimitNanoTon !== null && review.amountNanoTon > limits.perTransactionLimitNanoTon,
+    exceedsRemainingDailyLimit:
+      limits.remainingDailyLimitNanoTon !== null && review.amountNanoTon > limits.remainingDailyLimitNanoTon
+  };
+
+  return {
+    valid: true,
+    errors: [],
+    review: Object.freeze({
+      ...review,
+      riskIndicators: Object.freeze(createRiskIndicators(review, limits).map(Object.freeze)),
+      limitState: Object.freeze(limitState)
+    })
+  };
+}
+
+function createHistoryEntry(status, review, input = {}, now) {
+  if (!TON_TRANSACTION_HISTORY_STATUSES.includes(status)) {
+    throw new TonTransactionConfirmationError(`Unsupported TON transaction history status: ${status}`, 'unsupported_history_status');
+  }
+
+  return Object.freeze({
+    id: `${review.id}:${status}:${Date.parse(now)}`,
+    status,
+    transaction: clone(review),
+    timestamp: normalizeTimestamp(input.timestamp ?? now),
+    approval: input.approval === undefined ? null : clone(input.approval),
+    signed: input.signed === true,
+    requestedBy: input.requestedBy === undefined ? null : String(input.requestedBy),
+    reason: input.reason === undefined ? null : String(input.reason)
+  });
+}
+
+export function createTonTransactionConfirmationWorkflow(options = {}) {
+  assertApprovalBridge(options.approval);
+
+  const limits = normalizeLimits({ ...DEFAULT_LIMITS, ...(options.limits ?? {}) });
+  const now = typeof options.now === 'function' ? options.now : () => new Date().toISOString();
+  const approval = options.approval;
+  const reviews = new Map();
+  const history = [];
+
+  function recordHistory(status, review, input = {}) {
+    const entry = createHistoryEntry(status, review, input, normalizeTimestamp(now()));
+    history.push(entry);
+    return entry;
+  }
+
+  return Object.freeze({
+    createReview(input = {}) {
+      const validation = validateTonTransactionReview(input, limits);
+      if (!validation.valid) {
+        throw adapterError(validation.errors, 'invalid_transaction_review');
+      }
+
+      reviews.set(validation.review.id, validation.review);
+      recordHistory('pending', validation.review);
+      return clone(validation.review);
+    },
+    async approveTransaction(id, input = {}) {
+      const review = reviews.get(String(id ?? '').trim());
+      if (!review) {
+        throw new TonTransactionConfirmationError(`Unknown TON transaction review: ${id}`, 'unknown_transaction_review');
+      }
+
+      const availableMethods = normalizeApprovalMethods(input.approvalMethods ?? input.availableMethods);
+      const result = await approval.confirm({
+        transaction: clone(review),
+        availableMethods,
+        requestedBy: input.requestedBy === undefined ? null : String(input.requestedBy),
+        riskIndicators: clone(review.riskIndicators)
+      });
+
+      const approved = result?.approved === true;
+      const approvalRecord = {
+        method: String(result?.method ?? availableMethods[0]),
+        approvedAt: normalizeTimestamp(result?.approvedAt ?? now(), 'TON transaction approval timestamp')
+      };
+
+      if (approved) {
+        return recordHistory('approved', review, {
+          approval: approvalRecord,
+          requestedBy: input.requestedBy,
+          signed: false
+        });
+      }
+
+      return recordHistory('rejected', review, {
+        approval: approvalRecord,
+        requestedBy: input.requestedBy,
+        reason: result?.reason ?? 'TON transaction approval was rejected.'
+      });
+    },
+    markTransactionFailed(id, reason, input = {}) {
+      const review = reviews.get(String(id ?? '').trim());
+      if (!review) {
+        throw new TonTransactionConfirmationError(`Unknown TON transaction review: ${id}`, 'unknown_transaction_review');
+      }
+
+      return recordHistory('failed', review, {
+        ...input,
+        reason: reason ?? 'TON transaction failed.'
+      });
+    },
+    listHistory(filters = {}) {
+      let entries = history;
+      if (filters.status !== undefined) {
+        const status = String(filters.status).trim();
+        if (!TON_TRANSACTION_HISTORY_STATUSES.includes(status)) {
+          throw new TonTransactionConfirmationError(`Unsupported TON transaction history status: ${filters.status}`, 'unsupported_history_status');
+        }
+        entries = entries.filter((entry) => entry.status === status);
+      }
+
+      const latestByTransaction = new Map();
+      for (const entry of entries) {
+        latestByTransaction.set(entry.transaction.id, entry);
+      }
+
+      return [...latestByTransaction.values()].map(clone);
+    },
+    getReview(id) {
+      const review = reviews.get(String(id ?? '').trim());
+      return review === undefined ? null : clone(review);
+    }
+  });
+}
+
+export function createMockTonTransactionConfirmationWorkflow(seed = {}) {
+  const approvalRequests = [];
+  const approvalResults = [...(seed.approvalResults ?? [{ approved: true, method: 'biometric' }])];
+
+  const workflow = createTonTransactionConfirmationWorkflow({
+    limits: seed.limits,
+    now: seed.now,
+    approval: {
+      async confirm(request) {
+        approvalRequests.push(clone(request));
+        const result = approvalResults.length > 0 ? approvalResults.shift() : { approved: true, method: request.availableMethods[0] };
+        return clone(result);
+      }
+    }
+  });
+
+  return Object.freeze({
+    ...workflow,
+    getApprovalRequests() {
+      return approvalRequests.map(clone);
+    }
+  });
+}

--- a/test/ton-transaction-confirmation.test.mjs
+++ b/test/ton-transaction-confirmation.test.mjs
@@ -1,0 +1,167 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  createMockTonTransactionConfirmationWorkflow,
+  createTonTransactionConfirmationWorkflow,
+  TON_TRANSACTION_HISTORY_STATUSES,
+  validateTonTransactionReview
+} from '../src/ton/transaction-confirmation.mjs';
+
+test('TON transaction review exposes amount, recipient, network fee, provider, and risk indicators', () => {
+  const validation = validateTonTransactionReview(
+    {
+      id: 'tx-1',
+      amountNanoTon: 1500000000n,
+      recipient: 'EQDreceiverAddress',
+      networkFeeNanoTon: 25000000n,
+      provider: 'tonkeeper',
+      totalNanoTon: 1525000000n
+    },
+    {
+      perTransactionLimitNanoTon: 1000000000n,
+      highFeeNanoTon: 20000000n
+    }
+  );
+
+  assert.equal(validation.valid, true);
+  assert.deepEqual(validation.review, {
+    id: 'tx-1',
+    amountNanoTon: 1500000000n,
+    recipient: 'EQDreceiverAddress',
+    networkFeeNanoTon: 25000000n,
+    provider: 'tonkeeper',
+    totalNanoTon: 1525000000n,
+    memo: null,
+    riskIndicators: [
+      {
+        code: 'amount_exceeds_limit',
+        severity: 'high',
+        message: 'TON transaction amount exceeds the configured per-transaction limit.'
+      },
+      {
+        code: 'network_fee_high',
+        severity: 'medium',
+        message: 'TON transaction network fee is higher than the configured review threshold.'
+      }
+    ],
+    limitState: {
+      perTransactionLimitNanoTon: 1000000000n,
+      remainingDailyLimitNanoTon: null,
+      exceedsPerTransactionLimit: true,
+      exceedsRemainingDailyLimit: false
+    }
+  });
+});
+
+test('TON transaction confirmation requires biometric or password approval before signing', async () => {
+  const approvals = [];
+  const workflow = createTonTransactionConfirmationWorkflow({
+    approval: {
+      async confirm(request) {
+        approvals.push(request);
+        return { approved: true, method: request.availableMethods[0], approvedAt: '2026-04-26T12:00:00.000Z' };
+      }
+    },
+    now: () => '2026-04-26T11:59:00.000Z'
+  });
+
+  const review = workflow.createReview({
+    id: 'tx-approval',
+    amountNanoTon: 500000000n,
+    recipient: 'EQDreceiverAddress',
+    networkFeeNanoTon: 10000000n,
+    provider: 'tonkeeper'
+  });
+
+  await assert.rejects(() => workflow.approveTransaction(review.id, { approvalMethods: [] }), /biometric or password/);
+
+  const approval = await workflow.approveTransaction(review.id, {
+    approvalMethods: ['biometric', 'password'],
+    requestedBy: 'user:42'
+  });
+
+  assert.equal(approval.status, 'approved');
+  assert.equal(approval.approval.method, 'biometric');
+  assert.equal(approval.signed, false);
+  assert.equal(approvals.length, 1);
+  assert.equal(approvals[0].transaction.id, 'tx-approval');
+  assert.deepEqual(approvals[0].availableMethods, ['biometric', 'password']);
+});
+
+test('TON transaction confirmation records approved, rejected, failed, and pending history entries', async () => {
+  assert.deepEqual(TON_TRANSACTION_HISTORY_STATUSES, ['approved', 'rejected', 'failed', 'pending']);
+
+  const workflow = createMockTonTransactionConfirmationWorkflow({
+    approvalResults: [
+      { approved: true, method: 'password', approvedAt: '2026-04-26T12:00:00.000Z' },
+      { approved: false, method: 'password', reason: 'User rejected.', approvedAt: '2026-04-26T12:01:00.000Z' }
+    ],
+    now: () => '2026-04-26T12:00:00.000Z'
+  });
+
+  const approvedReview = workflow.createReview({
+    id: 'tx-approved',
+    amountNanoTon: 1n,
+    recipient: 'EQDreceiverAddress',
+    networkFeeNanoTon: 1n,
+    provider: 'tonkeeper'
+  });
+  const rejectedReview = workflow.createReview({
+    id: 'tx-rejected',
+    amountNanoTon: 2n,
+    recipient: 'EQDreceiverAddress',
+    networkFeeNanoTon: 1n,
+    provider: 'tonkeeper'
+  });
+  const pendingReview = workflow.createReview({
+    id: 'tx-pending',
+    amountNanoTon: 3n,
+    recipient: 'EQDreceiverAddress',
+    networkFeeNanoTon: 1n,
+    provider: 'tonkeeper'
+  });
+
+  await workflow.approveTransaction(approvedReview.id, { approvalMethods: ['password'] });
+  await workflow.approveTransaction(rejectedReview.id, { approvalMethods: ['password'] });
+  workflow.markTransactionFailed('tx-approved', 'Provider signing failed.');
+
+  assert.deepEqual(
+    workflow.listHistory().map((entry) => ({ id: entry.transaction.id, status: entry.status })),
+    [
+      { id: 'tx-approved', status: 'failed' },
+      { id: 'tx-rejected', status: 'rejected' },
+      { id: 'tx-pending', status: 'pending' }
+    ]
+  );
+  assert.match(workflow.listHistory().at(0).reason, /Provider signing failed/);
+  assert.equal(workflow.listHistory({ status: 'approved' }).at(0).transaction.id, 'tx-approved');
+  assert.equal(workflow.getApprovalRequests().length, 2);
+});
+
+test('TON transaction confirmation validates provider boundaries before approval hooks', async () => {
+  let called = false;
+  const workflow = createTonTransactionConfirmationWorkflow({
+    approval: {
+      async confirm() {
+        called = true;
+        return { approved: true, method: 'password' };
+      }
+    }
+  });
+
+  assert.throws(
+    () =>
+      workflow.createReview({
+        id: 'tx-invalid',
+        amountNanoTon: 0n,
+        recipient: '',
+        networkFeeNanoTon: -1n,
+        provider: ''
+      }),
+    /amountNanoTon must be a positive/
+  );
+
+  await assert.rejects(() => workflow.approveTransaction('missing', { approvalMethods: ['password'] }), /Unknown TON transaction review/);
+  assert.equal(called, false);
+});


### PR DESCRIPTION
## Summary
- Add a shared TON transaction confirmation workflow with review state for amount, recipient, network fee, provider, total, limits, and risk indicators.
- Require platform biometric or password approval hooks before callers continue toward signing.
- Record pending, approved, rejected, and failed transaction history states for audit views.
- Document the new confirmation boundary in README and architecture docs.

Fixes #17

## Reproduction and Verification
- Added `test/ton-transaction-confirmation.test.mjs` to cover transaction review fields, risk/limit indicators, approval requirements, history status recording, and validation before approval bridge calls.

## Tests
- `node --test test/ton-transaction-confirmation.test.mjs`
- `npm test`
- `npm run validate:foundation`
- `npm run validate:release`

## Screenshots
Not applicable: this PR adds the shared confirmation workflow boundary and tests, not a rendered UI shell.