### PR TITLE
Add TON testnet wallet flow coverage

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-26T15:09:05.693Z for PR creation at branch issue-18-8a1edcff3b47 for issue https://github.com/xlabtg/Teleton-Client/issues/18

--- a/BUILD-GUIDE.md
+++ b/BUILD-GUIDE.md
@@ -71,3 +71,17 @@ node scripts/decompose-epic.mjs --create --skip-label-create --repo xlabtg/Telet
 ## Environment
 
 Do not hardcode Telegram API credentials, proxy secrets, TON wallet secrets, cloud model tokens, or agent keys in source files. Use environment variables or platform secure storage references such as `env:TELETON_MTPROTO_SECRET`, `keychain:teleton-agent-token`, or `keystore:ton-wallet`.
+
+## TON Testnet Checks
+
+`test/ton-testnet-coverage.test.mjs` runs the TON wallet flow harness in mock mode by default, so local validation never needs wallet secrets or network access. Protected CI can opt into live testnet checks only when all required variables are present:
+
+| Variable | Required for live testnet | Secret | Purpose |
+| --- | --- | --- | --- |
+| `TELETON_TON_TESTNET_ENABLED` | yes | no | Set to `true` to enable live testnet checks. Any other value keeps mock mode. |
+| `TELETON_TON_TESTNET_WALLET_ADDRESS` | yes | no | Public testnet wallet address used for balance and receive-address checks. |
+| `TELETON_TON_TESTNET_PROVIDER_REF` | yes | yes | Secure provider reference resolved by protected CI or a platform wallet bridge. Do not store raw private keys, mnemonics, or seed phrases. |
+| `TELETON_TON_TESTNET_RECIPIENT_ADDRESS` | yes | no | Public testnet recipient address used for unsigned transfer draft checks. |
+| `TELETON_TON_TESTNET_TRANSFER_NANOTON` | no | no | Optional positive integer draft amount. Defaults to `1` nanotON for live checks and a mock fixture amount locally. |
+
+Rotate testnet credentials by creating a fresh testnet wallet/provider outside the repository, funding it only with faucet testnet TON, updating the protected CI secret that backs `TELETON_TON_TESTNET_PROVIDER_REF`, and replacing the public wallet/recipient variables in the protected environment. After rotation, run the protected testnet job once, then revoke or delete the previous provider reference. Never paste wallet provider material into issue comments, pull request descriptions, logs, screenshots, or committed fixtures.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This repository is in the foundation phase. The current implementation establish
 - TON wallet adapter contract for balance lookup, receive address display, transfer draft preparation, and status checks without plaintext private keys.
 - TON swap adapter contract for STON.fi and DeDust quote lookup plus confirmation-gated swap transaction draft preparation.
 - TON transaction confirmation workflow for review details, biometric or password approval hooks, limit/risk indicators, and status history.
+- TON testnet coverage harness that runs wallet flow checks in mock mode locally and requires explicit protected environment variables before live testnet execution.
 - Local Teleton Agent runtime supervisor contract with mock lifecycle tests for start, stop, health, resource monitoring, and logs.
 - Teleton Agent action notification contract for proposals, starts, completions, approval-required states, and failures with settings-aware delivery and redacted lock-screen text.
 - Teleton Agent action history contract for redacted action records, retention filtering, rollback eligibility, and irreversible action markers.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,6 +33,7 @@ Teleton Client is planned as a layered client where protocol, automation, wallet
 - TON signing requires user confirmation and platform secure storage or wallet-provider approval. Transfer preparation validates explicit confirmation before provider calls and still returns an unsigned draft for a later signing flow.
 - TON swap operations are represented by the `src/ton/swap-adapter.mjs` contract. Shared callers can request STON.fi or DeDust quotes without signing, while swap transaction draft preparation requires explicit confirmation and provider errors are sanitized before they cross the shared boundary.
 - TON transaction confirmation is represented by the `src/ton/transaction-confirmation.mjs` workflow. It builds review state with amount, recipient, network fee, provider, limit state, and risk indicators, then requires a platform biometric or password approval bridge before callers may continue to signing. The workflow records pending, approved, rejected, and failed history states for audit views.
+- TON testnet coverage is represented by the `src/ton/testnet-coverage.mjs` harness. It exercises balance, receive-address, unsigned transfer draft, transfer status, and confirmation paths in mock mode by default, and switches to live testnet mode only when protected CI supplies the explicit testnet environment contract.
 
 ## Local Agent Runtime
 

--- a/src/ton/testnet-coverage.mjs
+++ b/src/ton/testnet-coverage.mjs
@@ -1,0 +1,185 @@
+import { createMockTonWalletAdapter, createTonWalletAdapter } from './wallet-adapter.mjs';
+import { createMockTonTransactionConfirmationWorkflow } from './transaction-confirmation.mjs';
+
+export const TON_TESTNET_ENVIRONMENT = Object.freeze([
+  Object.freeze({
+    name: 'TELETON_TON_TESTNET_ENABLED',
+    requiredForTestnet: true,
+    secret: false,
+    description: 'Set to true only in protected CI or a trusted local shell to run live TON testnet checks.'
+  }),
+  Object.freeze({
+    name: 'TELETON_TON_TESTNET_WALLET_ADDRESS',
+    requiredForTestnet: true,
+    secret: false,
+    description: 'Public testnet wallet address used for balance, receive address, draft, and confirmation checks.'
+  }),
+  Object.freeze({
+    name: 'TELETON_TON_TESTNET_PROVIDER_REF',
+    requiredForTestnet: true,
+    secret: true,
+    description: 'Secure reference for the protected testnet wallet provider; never use a raw private key or mnemonic.'
+  }),
+  Object.freeze({
+    name: 'TELETON_TON_TESTNET_RECIPIENT_ADDRESS',
+    requiredForTestnet: true,
+    secret: false,
+    description: 'Public testnet recipient address used when preparing unsigned transfer drafts.'
+  }),
+  Object.freeze({
+    name: 'TELETON_TON_TESTNET_TRANSFER_NANOTON',
+    requiredForTestnet: false,
+    secret: false,
+    description: 'Optional positive integer transfer amount for draft checks; defaults to 1 nanotON.'
+  })
+]);
+
+const REQUIRED_TESTNET_ENVIRONMENT = TON_TESTNET_ENVIRONMENT.filter((entry) => entry.requiredForTestnet).map((entry) => entry.name);
+
+const DEFAULT_MOCK_FIXTURE = Object.freeze({
+  walletAddress: 'EQDmockTestnetWalletAddress',
+  recipientAddress: 'EQDmockTestnetRecipientAddress',
+  providerRef: 'wallet:mock-ton-testnet-provider',
+  balanceNanoTon: 5000000000n,
+  transferNanoTon: 100000000n,
+  networkFeeNanoTon: 1000000n
+});
+
+export class TonTestnetCoverageError extends Error {
+  constructor(message, code, details = []) {
+    super(message);
+    this.name = 'TonTestnetCoverageError';
+    this.code = code;
+    this.details = details;
+  }
+}
+
+function enabled(value) {
+  return ['1', 'true', 'yes'].includes(String(value ?? '').trim().toLowerCase());
+}
+
+function missingEnvironment(env) {
+  return REQUIRED_TESTNET_ENVIRONMENT.filter((name) => !String(env[name] ?? '').trim());
+}
+
+function parseTransferNanoTon(value, fallback) {
+  if (value === undefined || value === null || value === '') {
+    return fallback;
+  }
+
+  try {
+    const parsed = BigInt(value);
+    if (parsed > 0n) {
+      return parsed;
+    }
+  } catch {
+    // Fall through to the explicit validation error below.
+  }
+
+  throw new TonTestnetCoverageError(
+    'TELETON_TON_TESTNET_TRANSFER_NANOTON must be a positive integer when set.',
+    'invalid_testnet_transfer_amount'
+  );
+}
+
+function redactError(error) {
+  const message = error instanceof Error ? error.message : String(error ?? 'Unknown TON testnet coverage error.');
+  return message.replace(/\b(?:env|keychain|keystore|secret):[A-Za-z0-9_.:/-]+/g, '[secure-ref]');
+}
+
+function createTestnetAdapter(env, implementation) {
+  if (!implementation) {
+    throw new TonTestnetCoverageError(
+      'Live TON testnet coverage requires a provider implementation passed to createTonTestnetWalletFlowHarness.',
+      'missing_testnet_provider'
+    );
+  }
+
+  return createTonWalletAdapter(implementation, {
+    address: env.TELETON_TON_TESTNET_WALLET_ADDRESS,
+    walletProviderRef: env.TELETON_TON_TESTNET_PROVIDER_REF,
+    network: 'testnet'
+  });
+}
+
+export function createTonTestnetWalletFlowHarness(options = {}) {
+  const env = options.env ?? process.env;
+  const isTestnetEnabled = enabled(env.TELETON_TON_TESTNET_ENABLED);
+  const missing = isTestnetEnabled ? missingEnvironment(env) : ['TELETON_TON_TESTNET_ENABLED'];
+
+  if (isTestnetEnabled && missing.length > 0) {
+    throw new TonTestnetCoverageError(
+      `TON testnet checks are enabled but missing required environment variables: ${missing.join(', ')}.`,
+      'missing_testnet_environment',
+      missing
+    );
+  }
+
+  const mode = isTestnetEnabled ? 'testnet' : 'mock';
+  const transferNanoTon = parseTransferNanoTon(env.TELETON_TON_TESTNET_TRANSFER_NANOTON, DEFAULT_MOCK_FIXTURE.transferNanoTon);
+  const walletAddress = isTestnetEnabled
+    ? env.TELETON_TON_TESTNET_WALLET_ADDRESS
+    : options.mockFixture?.walletAddress ?? DEFAULT_MOCK_FIXTURE.walletAddress;
+  const recipientAddress = isTestnetEnabled
+    ? env.TELETON_TON_TESTNET_RECIPIENT_ADDRESS
+    : options.mockFixture?.recipientAddress ?? DEFAULT_MOCK_FIXTURE.recipientAddress;
+
+  return Object.freeze({
+    mode,
+    testnetEnabled: isTestnetEnabled,
+    missingEnvironment: Object.freeze([...missing]),
+    environmentContract: TON_TESTNET_ENVIRONMENT,
+    async runWalletFlow() {
+      const adapter = isTestnetEnabled
+        ? createTestnetAdapter(env, options.provider)
+        : createMockTonWalletAdapter({
+            address: walletAddress,
+            walletProviderRef: DEFAULT_MOCK_FIXTURE.providerRef,
+            balanceNanoTon: options.mockFixture?.balanceNanoTon ?? DEFAULT_MOCK_FIXTURE.balanceNanoTon,
+            network: 'testnet'
+          });
+
+      try {
+        const balance = await adapter.getBalance();
+        const receiveAddress = await adapter.getReceiveAddress();
+        const transferDraft = await adapter.prepareTransfer({
+          to: recipientAddress,
+          amountNanoTon: transferNanoTon,
+          memo: 'teleton testnet coverage draft',
+          confirmed: true
+        });
+        const transferStatus = await adapter.getTransferStatus(transferDraft.id);
+
+        const confirmationWorkflow = createMockTonTransactionConfirmationWorkflow({
+          approvalResults: [{ approved: true, method: 'password', approvedAt: options.now?.() ?? new Date().toISOString() }],
+          now: options.now
+        });
+        const review = confirmationWorkflow.createReview({
+          id: transferDraft.id,
+          amountNanoTon: transferDraft.amountNanoTon,
+          recipient: transferDraft.to,
+          networkFeeNanoTon: options.mockFixture?.networkFeeNanoTon ?? DEFAULT_MOCK_FIXTURE.networkFeeNanoTon,
+          provider: mode === 'testnet' ? 'testnet-provider' : 'mock-provider',
+          memo: transferDraft.memo
+        });
+        const confirmation = await confirmationWorkflow.approveTransaction(review.id, {
+          approvalMethods: ['password'],
+          requestedBy: 'testnet-coverage'
+        });
+
+        return Object.freeze({
+          mode,
+          testnetEnabled: isTestnetEnabled,
+          missingEnvironment: Object.freeze([...missing]),
+          balance,
+          receiveAddress,
+          transferDraft,
+          transferStatus,
+          confirmation
+        });
+      } catch (error) {
+        throw new TonTestnetCoverageError(redactError(error), 'testnet_wallet_flow_failed');
+      }
+    }
+  });
+}

--- a/test/ton-testnet-coverage.test.mjs
+++ b/test/ton-testnet-coverage.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  createTonTestnetWalletFlowHarness,
+  TON_TESTNET_ENVIRONMENT
+} from '../src/ton/testnet-coverage.mjs';
+
+test('TON testnet wallet flow runs in mock mode without secrets', async () => {
+  const harness = createTonTestnetWalletFlowHarness({
+    env: {},
+    now: () => '2026-04-26T12:00:00.000Z'
+  });
+
+  const result = await harness.runWalletFlow();
+
+  assert.equal(result.mode, 'mock');
+  assert.equal(result.testnetEnabled, false);
+  assert.deepEqual(result.missingEnvironment, ['TELETON_TON_TESTNET_ENABLED']);
+  assert.equal(result.balance.network, 'testnet');
+  assert.equal(result.receiveAddress.address, 'EQDmockTestnetWalletAddress');
+  assert.equal(result.transferDraft.status, 'draft');
+  assert.equal(result.transferStatus.status, 'draft');
+  assert.equal(result.confirmation.status, 'approved');
+  assert.equal(result.confirmation.signed, false);
+  assert.doesNotMatch(JSON.stringify(result, (_, value) => (typeof value === 'bigint' ? value.toString() : value)), /private|mnemonic|seed|secret|plaintext/i);
+});
+
+test('TON testnet wallet flow requires an explicit protected CI environment gate', async () => {
+  const harness = createTonTestnetWalletFlowHarness({
+    env: {
+      TELETON_TON_TESTNET_ENABLED: 'true',
+      TELETON_TON_TESTNET_WALLET_ADDRESS: 'EQDtestnetWalletAddress',
+      TELETON_TON_TESTNET_PROVIDER_REF: 'env:TELETON_TON_TESTNET_PROVIDER_REF',
+      TELETON_TON_TESTNET_RECIPIENT_ADDRESS: 'EQDtestnetRecipientAddress'
+    }
+  });
+
+  assert.equal(harness.mode, 'testnet');
+  assert.deepEqual(harness.missingEnvironment, []);
+});
+
+test('TON testnet wallet flow refuses partial testnet credentials', () => {
+  assert.throws(
+    () =>
+      createTonTestnetWalletFlowHarness({
+        env: {
+          TELETON_TON_TESTNET_ENABLED: 'true',
+          TELETON_TON_TESTNET_WALLET_ADDRESS: 'EQDtestnetWalletAddress'
+        }
+      }),
+    /missing required environment variables/i
+  );
+});
+
+test('TON testnet environment contract documents protected variables', () => {
+  assert.deepEqual(
+    TON_TESTNET_ENVIRONMENT.map((entry) => entry.name),
+    [
+      'TELETON_TON_TESTNET_ENABLED',
+      'TELETON_TON_TESTNET_WALLET_ADDRESS',
+      'TELETON_TON_TESTNET_PROVIDER_REF',
+      'TELETON_TON_TESTNET_RECIPIENT_ADDRESS',
+      'TELETON_TON_TESTNET_TRANSFER_NANOTON'
+    ]
+  );
+
+  assert.equal(TON_TESTNET_ENVIRONMENT.find((entry) => entry.name === 'TELETON_TON_TESTNET_PROVIDER_REF').secret, true);
+});


### PR DESCRIPTION
## Summary
- Add a TON testnet wallet flow harness that covers balance lookup, receive address retrieval, unsigned transfer draft preparation, transfer status lookup, and transaction confirmation.
- Keep local runs mock-backed and secret-free by default, while requiring an explicit protected environment contract before live testnet mode can run.
- Document required testnet variables and the credential rotation procedure in the build guide, with architecture and README references.

Fixes #18

## Reproduction and Verification
- Added `test/ton-testnet-coverage.test.mjs` to cover local mock mode, live testnet gating, partial-environment rejection, and secret metadata for the provider reference.
- Mock mode runs without TON wallet secrets or network access.
- Live testnet mode requires `TELETON_TON_TESTNET_ENABLED=true` plus the wallet address, provider reference, and recipient address variables documented in `BUILD-GUIDE.md`.

## Tests
- `node --test test/ton-adapter.test.mjs test/ton-transaction-confirmation.test.mjs test/ton-testnet-coverage.test.mjs`
- `npm test`
- `npm run validate:foundation`
- `npm run validate:release`
- `npm run decompose:dry-run`

## Screenshots
Not applicable: this PR adds a shared test coverage harness and documentation, not UI.
