### PR TITLE
Add Jetton token support

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-26T15:33:01.031Z for PR creation at branch issue-55-993e85945c70 for issue https://github.com/xlabtg/Teleton-Client/issues/55

--- a/src/ton/wallet-adapter.mjs
+++ b/src/ton/wallet-adapter.mjs
@@ -74,6 +74,118 @@ function normalizeNanoTon(value, errors) {
   return amountNanoTon;
 }
 
+function normalizePositiveAtomicAmount(value, fieldName, errors) {
+  let amount = value;
+  if (typeof amount === 'number' && Number.isSafeInteger(amount)) {
+    amount = BigInt(amount);
+  }
+
+  if (typeof amount !== 'bigint' || amount <= 0n) {
+    errors.push(`Jetton transfer ${fieldName} must be a positive bigint or safe integer.`);
+  }
+
+  return amount;
+}
+
+function normalizeNonNegativeAtomicAmount(value, fieldName, errors) {
+  let amount = value;
+  if (typeof amount === 'number' && Number.isSafeInteger(amount)) {
+    amount = BigInt(amount);
+  }
+
+  if (typeof amount !== 'bigint' || amount < 0n) {
+    errors.push(`Jetton balance ${fieldName} must be a non-negative bigint or safe integer.`);
+  }
+
+  return amount;
+}
+
+function normalizeOptionalAddress(value) {
+  const address = String(value ?? '').trim();
+  return address || null;
+}
+
+function isSafeHttpUrl(value) {
+  try {
+    const url = new URL(String(value));
+    return url.protocol === 'http:' || url.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+export function normalizeJettonMetadata(input) {
+  if (input === undefined || input === null) {
+    return {
+      address: '',
+      symbol: 'UNKNOWN',
+      name: 'Unknown Jetton',
+      decimals: 0,
+      imageUrl: null,
+      verified: false,
+      unknown: true,
+      warnings: ['Jetton metadata address is missing.', 'Jetton metadata is unavailable.']
+    };
+  }
+
+  const metadata = input && typeof input === 'object' ? input : {};
+  const warnings = [];
+  const address = String(metadata.address ?? metadata.masterAddress ?? '').trim();
+  const symbol = String(metadata.symbol ?? '').trim().toUpperCase();
+  const name = String(metadata.name ?? '').trim();
+  const decimals = Number(metadata.decimals);
+  const imageUrl = metadata.imageUrl ?? metadata.image ?? null;
+
+  if (!address) {
+    warnings.push('Jetton metadata address is missing.');
+  }
+
+  if (!symbol) {
+    warnings.push('Jetton metadata symbol is missing.');
+  }
+
+  if (!Number.isInteger(decimals) || decimals < 0 || decimals > 255) {
+    warnings.push('Jetton metadata decimals must be an integer between 0 and 255.');
+  }
+
+  if (imageUrl !== null && imageUrl !== undefined && !isSafeHttpUrl(imageUrl)) {
+    warnings.push('Jetton metadata imageUrl must be an http(s) URL.');
+  }
+
+  const unknown = warnings.length > 0;
+
+  return {
+    address,
+    symbol: symbol || 'UNKNOWN',
+    name: name || 'Unknown Jetton',
+    decimals: Number.isInteger(decimals) && decimals >= 0 && decimals <= 255 ? decimals : 0,
+    imageUrl: imageUrl !== null && imageUrl !== undefined && isSafeHttpUrl(imageUrl) ? String(imageUrl) : null,
+    verified: unknown ? false : metadata.verified === true,
+    unknown,
+    warnings
+  };
+}
+
+function normalizeJettonBalance(input = {}) {
+  const errors = [];
+  const masterAddress = normalizeAddress(input.masterAddress ?? input.jettonMasterAddress, 'Jetton master', errors);
+  const balanceAtomic = normalizeNonNegativeAtomicAmount(input.balanceAtomic, 'balanceAtomic', errors);
+
+  if (errors.length > 0) {
+    throw adapterError(errors, 'invalid_jetton_balance');
+  }
+
+  return {
+    walletAddress: normalizeOptionalAddress(input.walletAddress ?? input.jettonWalletAddress),
+    masterAddress,
+    balanceAtomic,
+    metadata: normalizeJettonMetadata({
+      address: masterAddress,
+      ...(input.metadata ?? {})
+    })
+  };
+}
+
 export function validateTonWalletConfig(input = {}) {
   const errors = [];
   collectPrivateKeyErrors(input, errors);
@@ -134,6 +246,39 @@ export function validateTonTransferRequest(input = {}, walletConfig = {}) {
   };
 }
 
+export function validateJettonTransferRequest(input = {}, walletConfig = {}) {
+  const errors = [];
+  collectPrivateKeyErrors(input, errors);
+
+  const request = {
+    from: normalizeAddress(walletConfig.address ?? input.from, 'sender', errors),
+    to: normalizeAddress(input.to, 'recipient', errors),
+    jettonMasterAddress: normalizeAddress(input.jettonMasterAddress ?? input.masterAddress, 'Jetton master', errors),
+    amountAtomic: normalizePositiveAtomicAmount(input.amountAtomic, 'amountAtomic', errors)
+  };
+
+  const jettonWalletAddress = normalizeOptionalAddress(input.jettonWalletAddress ?? input.walletAddress);
+  if (jettonWalletAddress) {
+    request.jettonWalletAddress = jettonWalletAddress;
+  }
+
+  if (input.memo !== undefined) {
+    request.memo = String(input.memo);
+  }
+
+  if (input.confirmed !== true) {
+    errors.push('Jetton transfer preparation requires explicit confirmation before signing.');
+  } else {
+    request.confirmed = true;
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+    request
+  };
+}
+
 function validateTransferStatusId(id) {
   const errors = [];
   const transferId = String(id ?? '').trim();
@@ -169,6 +314,24 @@ export function createTonWalletAdapter(implementation, options = {}) {
         ...balance
       };
     },
+    async getJettonBalances() {
+      if (typeof implementation.getJettonBalances !== 'function') {
+        return {
+          address: walletConfig.address,
+          network: walletConfig.network,
+          jettons: []
+        };
+      }
+
+      const balances = await implementation.getJettonBalances();
+      const jettons = Array.isArray(balances?.jettons) ? balances.jettons : balances;
+
+      return {
+        address: walletConfig.address,
+        network: walletConfig.network,
+        jettons: (Array.isArray(jettons) ? jettons : []).map(normalizeJettonBalance)
+      };
+    },
     async getReceiveAddress() {
       const receiveAddress = await implementation.getReceiveAddress();
       return {
@@ -184,6 +347,21 @@ export function createTonWalletAdapter(implementation, options = {}) {
       }
 
       return implementation.prepareTransfer(transferValidation.request);
+    },
+    async prepareJettonTransfer(input = {}) {
+      if (typeof implementation.prepareJettonTransfer !== 'function') {
+        throw new TonWalletAdapterError(
+          'TON wallet adapter implementation does not support Jetton transfer preparation.',
+          'unsupported_jetton_transfer'
+        );
+      }
+
+      const transferValidation = validateJettonTransferRequest(input, walletConfig);
+      if (!transferValidation.valid) {
+        throw adapterError(transferValidation.errors, 'invalid_jetton_transfer_request');
+      }
+
+      return implementation.prepareJettonTransfer(transferValidation.request);
     },
     async getTransferStatus(id) {
       const statusValidation = validateTransferStatusId(id);
@@ -224,6 +402,12 @@ export function createMockTonWalletAdapter(seed = {}) {
         balanceNanoTon: seed.balanceNanoTon ?? 0n
       };
     },
+    async getJettonBalances() {
+      commands.push({ method: 'getJettonBalances' });
+      return {
+        jettons: (seed.jettonBalances ?? []).map(cloneValue)
+      };
+    },
     async getReceiveAddress() {
       commands.push({ method: 'getReceiveAddress' });
       return {
@@ -237,6 +421,22 @@ export function createMockTonWalletAdapter(seed = {}) {
         status: 'draft',
         signed: false,
         requiresSigningConfirmation: true,
+        network: walletConfig.network,
+        ...request
+      };
+      nextDraftId += 1;
+      transferDrafts.set(draft.id, draft);
+
+      return cloneValue(draft);
+    },
+    async prepareJettonTransfer(request) {
+      commands.push({ method: 'prepareJettonTransfer', request: cloneValue(request) });
+      const draft = {
+        id: `mock-jetton-draft-${nextDraftId}`,
+        status: 'draft',
+        signed: false,
+        requiresSigningConfirmation: true,
+        assetType: 'jetton',
         network: walletConfig.network,
         ...request
       };

--- a/test/ton-adapter.test.mjs
+++ b/test/ton-adapter.test.mjs
@@ -4,6 +4,8 @@ import { test } from 'node:test';
 import {
   createMockTonWalletAdapter,
   createTonWalletAdapter,
+  normalizeJettonMetadata,
+  validateJettonTransferRequest,
   validateTonTransferRequest,
   validateTonWalletConfig
 } from '../src/ton/wallet-adapter.mjs';
@@ -148,6 +150,188 @@ test('TON transfer validation rejects secret material in transfer requests', () 
       amountNanoTon: 1n,
       confirmed: true,
       privateKey: 'plaintext-key'
+    },
+    { address: 'EQDsenderAddress' }
+  );
+
+  assert.equal(validation.valid, false);
+  assert.match(validation.errors.join('\n'), /private keys are not accepted/i);
+});
+
+test('Jetton metadata normalizes unknown and malformed token details safely', () => {
+  assert.deepEqual(normalizeJettonMetadata(), {
+    address: '',
+    symbol: 'UNKNOWN',
+    name: 'Unknown Jetton',
+    decimals: 0,
+    imageUrl: null,
+    verified: false,
+    unknown: true,
+    warnings: ['Jetton metadata address is missing.', 'Jetton metadata is unavailable.']
+  });
+
+  assert.deepEqual(
+    normalizeJettonMetadata({
+      address: ' EQDjettonMaster ',
+      symbol: '   ',
+      name: 123,
+      decimals: 'not-a-number',
+      imageUrl: 'javascript:alert(1)',
+      verified: true
+    }),
+    {
+      address: 'EQDjettonMaster',
+      symbol: 'UNKNOWN',
+      name: '123',
+      decimals: 0,
+      imageUrl: null,
+      verified: false,
+      unknown: true,
+      warnings: [
+        'Jetton metadata symbol is missing.',
+        'Jetton metadata decimals must be an integer between 0 and 255.',
+        'Jetton metadata imageUrl must be an http(s) URL.'
+      ]
+    }
+  );
+});
+
+test('mock TON adapter returns Jetton balances with safe metadata fallbacks', async () => {
+  const adapter = createMockTonWalletAdapter({
+    address: 'EQDownerAddress',
+    walletProviderRef: 'wallet:tonkeeper:test-wallet',
+    jettonBalances: [
+      {
+        walletAddress: 'EQDjettonWallet',
+        masterAddress: 'EQDjettonMaster',
+        balanceAtomic: 2500000n,
+        metadata: {
+          address: 'EQDjettonMaster',
+          symbol: 'USDT',
+          name: 'Tether USD',
+          decimals: 6,
+          imageUrl: 'https://static.example/usdt.png',
+          verified: true
+        }
+      },
+      {
+        masterAddress: 'EQDunknownMaster',
+        balanceAtomic: 5n,
+        metadata: {
+          address: 'EQDunknownMaster',
+          symbol: '',
+          decimals: -1
+        }
+      }
+    ]
+  });
+
+  assert.deepEqual(await adapter.getJettonBalances(), {
+    address: 'EQDownerAddress',
+    network: 'testnet',
+    jettons: [
+      {
+        walletAddress: 'EQDjettonWallet',
+        masterAddress: 'EQDjettonMaster',
+        balanceAtomic: 2500000n,
+        metadata: {
+          address: 'EQDjettonMaster',
+          symbol: 'USDT',
+          name: 'Tether USD',
+          decimals: 6,
+          imageUrl: 'https://static.example/usdt.png',
+          verified: true,
+          unknown: false,
+          warnings: []
+        }
+      },
+      {
+        walletAddress: null,
+        masterAddress: 'EQDunknownMaster',
+        balanceAtomic: 5n,
+        metadata: {
+          address: 'EQDunknownMaster',
+          symbol: 'UNKNOWN',
+          name: 'Unknown Jetton',
+          decimals: 0,
+          imageUrl: null,
+          verified: false,
+          unknown: true,
+          warnings: [
+            'Jetton metadata symbol is missing.',
+            'Jetton metadata decimals must be an integer between 0 and 255.'
+          ]
+        }
+      }
+    ]
+  });
+});
+
+test('Jetton transfer preparation requires explicit confirmation and validates token inputs', async () => {
+  const adapter = createMockTonWalletAdapter({
+    address: 'EQDsenderAddress',
+    walletProviderRef: 'wallet:tonkeeper:test-wallet'
+  });
+
+  await assert.rejects(
+    () =>
+      adapter.prepareJettonTransfer({
+        jettonMasterAddress: 'EQDjettonMaster',
+        to: 'EQDreceiverAddress',
+        amountAtomic: 100n
+      }),
+    /explicit confirmation/
+  );
+
+  await assert.rejects(
+    () =>
+      adapter.prepareJettonTransfer({
+        jettonMasterAddress: '',
+        to: 'EQDreceiverAddress',
+        amountAtomic: 100n,
+        confirmed: true
+      }),
+    /Jetton master/
+  );
+
+  const draft = await adapter.prepareJettonTransfer({
+    jettonMasterAddress: 'EQDjettonMaster',
+    jettonWalletAddress: 'EQDjettonWallet',
+    to: 'EQDreceiverAddress',
+    amountAtomic: 100n,
+    memo: 'token payout',
+    confirmed: true
+  });
+
+  assert.equal(draft.status, 'draft');
+  assert.equal(draft.requiresSigningConfirmation, true);
+  assert.equal(draft.signed, false);
+  assert.equal(draft.assetType, 'jetton');
+  assert.equal(draft.from, 'EQDsenderAddress');
+  assert.equal(draft.to, 'EQDreceiverAddress');
+  assert.equal(draft.amountAtomic, 100n);
+  assert.deepEqual(adapter.getCommands().at(-1), {
+    method: 'prepareJettonTransfer',
+    request: {
+      from: 'EQDsenderAddress',
+      to: 'EQDreceiverAddress',
+      jettonMasterAddress: 'EQDjettonMaster',
+      jettonWalletAddress: 'EQDjettonWallet',
+      amountAtomic: 100n,
+      memo: 'token payout',
+      confirmed: true
+    }
+  });
+});
+
+test('Jetton transfer validation rejects secret material', () => {
+  const validation = validateJettonTransferRequest(
+    {
+      to: 'EQDreceiverAddress',
+      jettonMasterAddress: 'EQDjettonMaster',
+      amountAtomic: 1n,
+      confirmed: true,
+      mnemonic: 'secret words'
     },
     { address: 'EQDsenderAddress' }
   );


### PR DESCRIPTION
## Summary
- add Jetton metadata normalization with safe fallbacks for unknown or malformed token data
- expose Jetton balance lookup through the TON wallet adapter and mock adapter
- add Jetton transfer draft preparation with explicit confirmation and secret-material validation

## Reproduction and Verification
- Reproduces issue #55 coverage with new tests for unknown metadata, malformed metadata, balance lookup, transfer validation, and confirmation-required transfer drafts.

## Local Validation
- npm test
- npm run validate:foundation
- npm run validate:release
- npm run decompose:dry-run

Fixes #55