### PR TITLE
Add TON multi-wallet support

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-04-26T15:33:01.031Z for PR creation at branch issue-55-993e85945c70 for issue https://github.com/xlabtg/Teleton-Client/issues/55
 # Updated: 2026-04-26T15:37:00.991Z
+# Updated: 2026-04-26T15:41:17.747Z

--- a/src/ton/testnet-coverage.mjs
+++ b/src/ton/testnet-coverage.mjs
@@ -160,6 +160,12 @@ export function createTonTestnetWalletFlowHarness(options = {}) {
           recipient: transferDraft.to,
           networkFeeNanoTon: options.mockFixture?.networkFeeNanoTon ?? DEFAULT_MOCK_FIXTURE.networkFeeNanoTon,
           provider: mode === 'testnet' ? 'testnet-provider' : 'mock-provider',
+          wallet: transferDraft.wallet ?? {
+            id: 'testnet-coverage-wallet',
+            label: 'Testnet coverage wallet',
+            address: transferDraft.from,
+            network: transferDraft.network
+          },
           memo: transferDraft.memo
         });
         const confirmation = await confirmationWorkflow.approveTransaction(review.id, {

--- a/src/ton/transaction-confirmation.mjs
+++ b/src/ton/transaction-confirmation.mjs
@@ -37,6 +37,25 @@ function normalizeId(value, label, errors) {
   return id;
 }
 
+function normalizeWalletContext(input, errors) {
+  if (input === undefined || input === null) {
+    errors.push('TON transaction signing wallet is required.');
+    return null;
+  }
+
+  if (!isPlainObject(input)) {
+    errors.push('TON transaction signing wallet must be an object.');
+    return null;
+  }
+
+  return {
+    id: normalizeId(input.id, 'wallet id', errors),
+    label: String(input.label ?? '').trim() || normalizeId(input.address, 'wallet address', errors),
+    address: normalizeId(input.address, 'wallet address', errors),
+    network: String(input.network ?? '').trim() || null
+  };
+}
+
 function normalizePositiveNanoTon(value, fieldName, errors) {
   let amount = value;
   if (typeof amount === 'number' && Number.isSafeInteger(amount)) {
@@ -182,6 +201,7 @@ export function validateTonTransactionReview(input = {}, limitInput = {}) {
     recipient: normalizeId(input.recipient ?? input.to, 'recipient', errors),
     networkFeeNanoTon,
     provider: normalizeId(input.provider, 'provider', errors),
+    wallet: normalizeWalletContext(input.wallet, errors),
     totalNanoTon,
     memo: input.memo === undefined || input.memo === null ? null : String(input.memo)
   };

--- a/src/ton/wallet-adapter.mjs
+++ b/src/ton/wallet-adapter.mjs
@@ -61,6 +61,47 @@ function normalizeAddress(value, label, errors) {
   return address;
 }
 
+function normalizeWalletId(value, errors) {
+  const id = String(value ?? '').trim();
+  if (!id) {
+    errors.push('TON wallet id is required.');
+  }
+
+  return id;
+}
+
+function normalizeWalletLabel(value, address) {
+  const label = String(value ?? '').trim();
+  return label || address;
+}
+
+function normalizeWalletIdentity(input = {}, active = false) {
+  const validation = validateTonWalletConfig(input);
+  const errors = [...validation.errors];
+  const id = normalizeWalletId(input.id, errors);
+  const label = normalizeWalletLabel(input.label, validation.config.address);
+
+  if (errors.length > 0) {
+    throw adapterError(errors, 'invalid_wallet_identity');
+  }
+
+  return Object.freeze({
+    id,
+    label,
+    ...validation.config,
+    active
+  });
+}
+
+function toWalletSigningContext(wallet) {
+  return Object.freeze({
+    id: wallet.id,
+    label: wallet.label,
+    address: wallet.address,
+    network: wallet.network
+  });
+}
+
 function normalizeNanoTon(value, errors) {
   let amountNanoTon = value;
   if (typeof amountNanoTon === 'number' && Number.isSafeInteger(amountNanoTon)) {
@@ -302,7 +343,11 @@ export function createTonWalletAdapter(implementation, options = {}) {
     throw adapterError(validation.errors, 'invalid_wallet_config');
   }
 
-  const walletConfig = validation.config;
+  const walletConfig = {
+    ...(options.id === undefined ? {} : { id: String(options.id).trim() }),
+    ...(options.label === undefined ? {} : { label: normalizeWalletLabel(options.label, validation.config.address) }),
+    ...validation.config
+  };
 
   return Object.freeze({
     network: walletConfig.network,
@@ -346,7 +391,13 @@ export function createTonWalletAdapter(implementation, options = {}) {
         throw adapterError(transferValidation.errors, 'invalid_transfer_request');
       }
 
-      return implementation.prepareTransfer(transferValidation.request);
+      const draft = await implementation.prepareTransfer(transferValidation.request);
+      return walletConfig.id
+        ? {
+            ...draft,
+            wallet: toWalletSigningContext(walletConfig)
+          }
+        : draft;
     },
     async prepareJettonTransfer(input = {}) {
       if (typeof implementation.prepareJettonTransfer !== 'function') {
@@ -374,23 +425,132 @@ export function createTonWalletAdapter(implementation, options = {}) {
   });
 }
 
+export function createTonWalletManager(options = {}) {
+  const wallets = new Map();
+  let activeWalletId = null;
+
+  function listWallets() {
+    return [...wallets.values()].map((wallet) => ({ ...wallet, active: wallet.id === activeWalletId }));
+  }
+
+  function getWallet(id) {
+    const walletId = String(id ?? '').trim();
+    const wallet = wallets.get(walletId);
+    if (!wallet) {
+      throw new TonWalletAdapterError(`Unknown TON wallet: ${walletId}`, 'unknown_wallet');
+    }
+
+    return wallet;
+  }
+
+  function setWallet(wallet) {
+    wallets.set(wallet.id, Object.freeze({ ...wallet, active: false }));
+  }
+
+  const manager = {
+    listWallets,
+    getWallet(id) {
+      const wallet = getWallet(id);
+      return { ...wallet, active: wallet.id === activeWalletId };
+    },
+    getActiveWallet() {
+      if (!activeWalletId) {
+        throw new TonWalletAdapterError('No active TON wallet is selected.', 'missing_active_wallet');
+      }
+
+      return manager.getWallet(activeWalletId);
+    },
+    addWallet(input = {}) {
+      const wallet = normalizeWalletIdentity(input, wallets.size === 0);
+      if (wallets.has(wallet.id)) {
+        throw new TonWalletAdapterError(`TON wallet already exists: ${wallet.id}`, 'duplicate_wallet');
+      }
+
+      setWallet(wallet);
+      if (!activeWalletId || input.active === true) {
+        activeWalletId = wallet.id;
+      }
+
+      return manager.getWallet(wallet.id);
+    },
+    switchWallet(id) {
+      const wallet = getWallet(id);
+      activeWalletId = wallet.id;
+      return manager.getWallet(wallet.id);
+    },
+    renameWallet(id, label) {
+      const wallet = getWallet(id);
+      const renamed = Object.freeze({
+        ...wallet,
+        label: normalizeWalletLabel(label, wallet.address)
+      });
+      setWallet(renamed);
+      return manager.getWallet(renamed.id);
+    },
+    removeWallet(id) {
+      const wallet = getWallet(id);
+      wallets.delete(wallet.id);
+
+      if (activeWalletId === wallet.id) {
+        activeWalletId = wallets.size > 0 ? wallets.keys().next().value : null;
+      }
+
+      const secureRefs = [wallet.secureStorageRef, wallet.walletProviderRef].filter(Boolean);
+
+      return Object.freeze({
+        removed: Object.freeze({
+          id: wallet.id,
+          address: wallet.address,
+          secureRefs: Object.freeze(secureRefs)
+        }),
+        activeWallet: activeWalletId ? manager.getActiveWallet() : null
+      });
+    },
+    createActiveWalletAdapter(factory) {
+      if (typeof factory !== 'function') {
+        throw new TonWalletAdapterError('TON wallet manager requires an adapter factory function.', 'invalid_adapter_factory');
+      }
+
+      return factory(manager.getActiveWallet());
+    }
+  };
+
+  for (const wallet of options.wallets ?? []) {
+    manager.addWallet(wallet);
+  }
+
+  if (options.activeWalletId !== undefined) {
+    manager.switchWallet(options.activeWalletId);
+  }
+
+  return Object.freeze(manager);
+}
+
 function cloneValue(value) {
   return structuredClone(value);
 }
 
 export function createMockTonWalletAdapter(seed = {}) {
-  const validation = validateTonWalletConfig({
+  const walletInput = {
     address: seed.address,
     walletProviderRef: seed.walletProviderRef ?? 'wallet:mock-ton-provider',
     secureStorageRef: seed.secureStorageRef,
     network: seed.network ?? 'testnet'
-  });
+  };
+  const validation = validateTonWalletConfig(walletInput);
 
   if (!validation.valid) {
     throw adapterError(validation.errors, 'invalid_wallet_config');
   }
 
-  const walletConfig = validation.config;
+  const walletConfig =
+    seed.id === undefined
+      ? validation.config
+      : {
+          id: String(seed.id).trim(),
+          label: normalizeWalletLabel(seed.label, validation.config.address),
+          ...validation.config
+        };
   const commands = [];
   const transferDrafts = new Map();
   let nextDraftId = 1;

--- a/test/ton-adapter.test.mjs
+++ b/test/ton-adapter.test.mjs
@@ -3,12 +3,99 @@ import { test } from 'node:test';
 
 import {
   createMockTonWalletAdapter,
+  createTonWalletManager,
   createTonWalletAdapter,
   normalizeJettonMetadata,
   validateJettonTransferRequest,
   validateTonTransferRequest,
   validateTonWalletConfig
 } from '../src/ton/wallet-adapter.mjs';
+
+test('TON wallet manager adds, switches, renames, and removes wallet references without exposing secrets', () => {
+  const manager = createTonWalletManager();
+
+  const primary = manager.addWallet({
+    id: 'wallet-primary',
+    label: 'Primary',
+    address: 'EQDprimaryAddress',
+    walletProviderRef: 'wallet:tonkeeper:primary'
+  });
+  const savings = manager.addWallet({
+    id: 'wallet-savings',
+    label: 'Savings',
+    address: 'EQDsavingsAddress',
+    secureStorageRef: 'keystore:ton-wallet-savings',
+    network: 'mainnet'
+  });
+
+  assert.equal(primary.active, true);
+  assert.equal(savings.active, false);
+  assert.equal(manager.getActiveWallet().id, 'wallet-primary');
+
+  manager.switchWallet('wallet-savings');
+  assert.equal(manager.getActiveWallet().id, 'wallet-savings');
+  assert.deepEqual(
+    manager.listWallets().map((wallet) => ({ id: wallet.id, label: wallet.label, active: wallet.active })),
+    [
+      { id: 'wallet-primary', label: 'Primary', active: false },
+      { id: 'wallet-savings', label: 'Savings', active: true }
+    ]
+  );
+
+  assert.deepEqual(manager.renameWallet('wallet-savings', 'Long-term savings'), {
+    id: 'wallet-savings',
+    label: 'Long-term savings',
+    address: 'EQDsavingsAddress',
+    network: 'mainnet',
+    secureStorageRef: 'keystore:ton-wallet-savings',
+    active: true
+  });
+
+  const removal = manager.removeWallet('wallet-savings');
+  assert.deepEqual(removal.removed.secureRefs, ['keystore:ton-wallet-savings']);
+  assert.equal(manager.getActiveWallet().id, 'wallet-primary');
+});
+
+test('TON wallet manager prepares transfers with the selected wallet signing boundary', async () => {
+  const manager = createTonWalletManager({
+    wallets: [
+      {
+        id: 'wallet-primary',
+        label: 'Primary',
+        address: 'EQDprimaryAddress',
+        walletProviderRef: 'wallet:tonkeeper:primary'
+      },
+      {
+        id: 'wallet-savings',
+        label: 'Savings',
+        address: 'EQDsavingsAddress',
+        walletProviderRef: 'wallet:tonkeeper:savings'
+      }
+    ],
+    activeWalletId: 'wallet-savings'
+  });
+
+  const adapter = manager.createActiveWalletAdapter((wallet) =>
+    createMockTonWalletAdapter({
+      id: wallet.id,
+      label: wallet.label,
+      address: wallet.address,
+      walletProviderRef: wallet.walletProviderRef,
+      network: wallet.network
+    })
+  );
+
+  const draft = await adapter.prepareTransfer({
+    to: 'EQDreceiverAddress',
+    amountNanoTon: 25n,
+    confirmed: true
+  });
+
+  assert.equal(draft.from, 'EQDsavingsAddress');
+  assert.equal(draft.wallet.id, 'wallet-savings');
+  assert.equal(draft.wallet.label, 'Savings');
+  assert.equal(draft.wallet.address, 'EQDsavingsAddress');
+});
 
 test('TON wallet config rejects plaintext private keys and accepts provider references', () => {
   const invalid = validateTonWalletConfig({

--- a/test/ton-transaction-confirmation.test.mjs
+++ b/test/ton-transaction-confirmation.test.mjs
@@ -16,6 +16,12 @@ test('TON transaction review exposes amount, recipient, network fee, provider, a
       recipient: 'EQDreceiverAddress',
       networkFeeNanoTon: 25000000n,
       provider: 'tonkeeper',
+      wallet: {
+        id: 'wallet-primary',
+        label: 'Primary',
+        address: 'EQDsenderAddress',
+        network: null
+      },
       totalNanoTon: 1525000000n
     },
     {
@@ -31,6 +37,12 @@ test('TON transaction review exposes amount, recipient, network fee, provider, a
     recipient: 'EQDreceiverAddress',
     networkFeeNanoTon: 25000000n,
     provider: 'tonkeeper',
+    wallet: {
+      id: 'wallet-primary',
+      label: 'Primary',
+      address: 'EQDsenderAddress',
+      network: null
+    },
     totalNanoTon: 1525000000n,
     memo: null,
     riskIndicators: [
@@ -71,7 +83,8 @@ test('TON transaction confirmation requires biometric or password approval befor
     amountNanoTon: 500000000n,
     recipient: 'EQDreceiverAddress',
     networkFeeNanoTon: 10000000n,
-    provider: 'tonkeeper'
+    provider: 'tonkeeper',
+    wallet: { id: 'wallet-primary', label: 'Primary', address: 'EQDsenderAddress' }
   });
 
   await assert.rejects(() => workflow.approveTransaction(review.id, { approvalMethods: [] }), /biometric or password/);
@@ -105,21 +118,24 @@ test('TON transaction confirmation records approved, rejected, failed, and pendi
     amountNanoTon: 1n,
     recipient: 'EQDreceiverAddress',
     networkFeeNanoTon: 1n,
-    provider: 'tonkeeper'
+    provider: 'tonkeeper',
+    wallet: { id: 'wallet-primary', label: 'Primary', address: 'EQDsenderAddress' }
   });
   const rejectedReview = workflow.createReview({
     id: 'tx-rejected',
     amountNanoTon: 2n,
     recipient: 'EQDreceiverAddress',
     networkFeeNanoTon: 1n,
-    provider: 'tonkeeper'
+    provider: 'tonkeeper',
+    wallet: { id: 'wallet-primary', label: 'Primary', address: 'EQDsenderAddress' }
   });
   const pendingReview = workflow.createReview({
     id: 'tx-pending',
     amountNanoTon: 3n,
     recipient: 'EQDreceiverAddress',
     networkFeeNanoTon: 1n,
-    provider: 'tonkeeper'
+    provider: 'tonkeeper',
+    wallet: { id: 'wallet-primary', label: 'Primary', address: 'EQDsenderAddress' }
   });
 
   await workflow.approveTransaction(approvedReview.id, { approvalMethods: ['password'] });


### PR DESCRIPTION
## Summary
- Adds a TON wallet manager for multiple wallet identities, labels, active wallet selection, rename, removal, and secure-reference cleanup metadata.
- Threads selected-wallet signing context into transfer drafts and transaction confirmation reviews so users can see which wallet will sign.
- Updates testnet coverage harness and unit tests for multi-wallet lifecycle and selected-wallet transaction preparation.

## Reproduction / Verification
- Reproduces issue scope with `test/ton-adapter.test.mjs` multi-wallet add/switch/rename/remove coverage and selected-wallet transfer preparation coverage.
- Verifies confirmation signing context with `test/ton-transaction-confirmation.test.mjs` wallet context assertions.

## Validation
- `node --test test/ton-adapter.test.mjs test/ton-transaction-confirmation.test.mjs test/ton-testnet-coverage.test.mjs`
- `npm test`
- `npm run validate:foundation`
- `npm run validate:release`
- `npm run decompose:dry-run`

Fixes #57
