### PR TITLE
Add Android wrapper contract

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,4 @@
 # .gitkeep file auto-generated at 2026-04-26T15:33:01.031Z for PR creation at branch issue-55-993e85945c70 for issue https://github.com/xlabtg/Teleton-Client/issues/55
 # Updated: 2026-04-26T15:37:00.991Z
 # Updated: 2026-04-26T15:41:17.747Z
+# Updated: 2026-04-26T15:46:55.235Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,4 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-26T15:33:01.031Z for PR creation at branch issue-55-993e85945c70 for issue https://github.com/xlabtg/Teleton-Client/issues/55
-# Updated: 2026-04-26T15:37:00.991Z
-# Updated: 2026-04-26T15:41:17.747Z
-# Updated: 2026-04-26T15:46:55.235Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,3 @@
+# .gitkeep file auto-generated at 2026-04-26T15:33:01.031Z for PR creation at branch issue-55-993e85945c70 for issue https://github.com/xlabtg/Teleton-Client/issues/55
+# Updated: 2026-04-26T15:37:00.991Z
+# Updated: 2026-04-26T15:41:17.747Z

--- a/BUILD-GUIDE.md
+++ b/BUILD-GUIDE.md
@@ -21,6 +21,16 @@ Future TDLib build work should produce:
 
 TDLib is distributed under the Boost Software License 1.0 (`BSL-1.0`). Future build scripts must preserve upstream license notices, record the TDLib source revision, and document local patches or packaging changes. See `docs/tdlib-adapter.md` for the adapter boundary and credential-handling rules.
 
+## Android Wrapper
+
+The Android wrapper contract in `src/platform/android-wrapper.mjs` selects Kotlin, Jetpack Compose, and the Gradle Android Plugin for the future native shell. The debug artifact contract is an installable APK at:
+
+```text
+android/app/build/outputs/apk/debug/app-debug.apk
+```
+
+The contract declares package `dev.teleton.client`, entry activity `dev.teleton.client.MainActivity`, Android notification channels, WorkManager jobs for message and TON synchronization, an app-private foreground service for the local Teleton Agent runtime, and deep-link routing for Telegram and TON flows. See `docs/android-wrapper.md` for the platform API mapping.
+
 ## Local Checks
 
 Run the same checks used by CI:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This repository is in the foundation phase. The current implementation establish
 - TON staking adapter contract for Tonstakers and Whales previews, explicit risk/fee disclosure, rewards previews, and confirmation-gated unsigned stake/unstake drafts.
 - TON transaction confirmation workflow for review details, biometric or password approval hooks, limit/risk indicators, and status history.
 - TON testnet coverage harness that runs wallet flow checks in mock mode locally and requires explicit protected environment variables before live testnet execution.
+- Android wrapper contract for the Kotlin/Jetpack Compose stack, runnable debug APK artifact metadata, notification channels, WorkManager and foreground service boundaries, and Telegram/TON deep-link routing.
 - Local Teleton Agent runtime supervisor contract with mock lifecycle tests for start, stop, health, resource monitoring, and logs.
 - Teleton Agent action notification contract for proposals, starts, completions, approval-required states, and failures with settings-aware delivery and redacted lock-screen text.
 - Teleton Agent action history contract for redacted action records, retention filtering, rollback eligibility, and irreversible action markers.
@@ -58,7 +59,7 @@ The project is intended to evolve through these layers:
 4. TON blockchain integrations for wallet, transfers, swaps, NFTs, staking, and DNS.
 5. Security and privacy controls for credentials, user consent, and auditability.
 
-See `docs/architecture.md`, `docs/backlog.md`, `docs/tdlib-adapter.md`, and `docs/release-strategy.md` for the current foundation plan. The agent settings and local runtime sections in `docs/architecture.md` record the shared settings UI contract, supported runtime directions, and packaging gaps for Android, iOS, desktop, and web wrappers.
+See `docs/architecture.md`, `docs/backlog.md`, `docs/tdlib-adapter.md`, `docs/android-wrapper.md`, and `docs/release-strategy.md` for the current foundation plan. The agent settings, local runtime, and Android wrapper sections record the shared settings UI contract, supported runtime directions, platform execution boundaries, and remaining packaging gaps for Android, iOS, desktop, and web wrappers.
 
 ## Contribution Templates
 

--- a/docs/android-wrapper.md
+++ b/docs/android-wrapper.md
@@ -1,0 +1,41 @@
+# Android Wrapper
+
+The Android wrapper contract selects a Kotlin Android runtime with Jetpack Compose UI, the Gradle Android Plugin build system, and package name `dev.teleton.client`. The debug variant is represented by the installable artifact contract `android/app/build/outputs/apk/debug/app-debug.apk`, launched through `dev.teleton.client.MainActivity`.
+
+This repository still keeps the implementation dependency-free, so the wrapper is modeled as a shared contract that future native Gradle sources can consume. The contract records the selected stack, runnable debug artifact metadata, notification channels, background execution boundaries, and deep-link routing into shared messaging, settings, agent, proxy, and TON workflows.
+
+## Notifications
+
+Android notification requests are generated from the shared notification payloads. The platform request uses `NotificationCompat`, declares the Android 13+ `POST_NOTIFICATIONS` runtime permission requirement, and maps user-visible categories to private lock-screen channels:
+
+- `messages` for Telegram message events.
+- `agent_actions` for approval-required and informational Teleton Agent action events.
+- `agent_runtime` for foreground service status.
+- `wallet` for TON wallet and transaction status events.
+
+Lock-screen copy stays redacted, and pending intents carry sanitized payload metadata rather than message text, chat titles, prompts, tokens, or wallet secrets.
+
+## Background Work
+
+Long-running local agent execution is modeled as an app-private `ForegroundService` named `dev.teleton.client.agent.TeletonAgentForegroundService`. It is not exported, uses the `agent_runtime` notification channel, declares the `dataSync` foreground service type, and is started only through user-initiated or notification-action flows.
+
+Message synchronization uses `WorkManager` through `dev.teleton.client.sync.MessageSyncWorker`. Expedited work requires foreground info so Android can display the user-visible notification required for expedited or foreground execution.
+
+TON status refresh uses `WorkManager` through `dev.teleton.client.ton.TonStatusRefreshWorker` with connected-network and battery-not-low constraints. It is not expedited because wallet status polling should not consume foreground service quota.
+
+## Deep Links
+
+`MainActivity` is the single Android deep-link entry point. It uses `android.intent.action.VIEW` with `DEFAULT` and `BROWSABLE` categories for the supported schemes `teleton`, `tg`, `ton`, and verified `https` app links.
+
+Supported Telegram routes include:
+
+- `tg://resolve?domain=teleton` to `messaging.openChat`.
+- `tg://resolve?domain=teleton&post=42` to `messaging.openMessage`.
+- `https://t.me/teleton/42` to `messaging.openMessage`.
+
+Supported TON routes include:
+
+- `ton://transfer/EQExampleAddress?amount=1000&text=coffee` to `ton.transfer.review`.
+- `ton://dns/example.ton` to `ton.dns.resolve`.
+
+All TON transfer deep links route to a review workflow with `requiresConfirmation: true`; the wrapper contract never treats a link as authorization to sign or broadcast a transaction.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,6 +16,7 @@ Teleton Client is planned as a layered client where protocol, automation, wallet
 
 - TDLib credentials must be supplied at runtime and never committed.
 - TDLib callers use the shared `authenticate`, `getChatList`, `sendMessage`, and `subscribeUpdates` adapter contract so Android, iOS, desktop, and web-compatible bridges expose the same boundary.
+- The Android wrapper is represented by `src/platform/android-wrapper.mjs`. It selects Kotlin, Jetpack Compose, and the Gradle Android Plugin for the native shell; exposes runnable debug APK artifact metadata; maps notifications and background work to Android channels, WorkManager, and an app-private foreground service; and routes Telegram and TON deep links to shared workflows.
 - Agent mode defaults to `off`; cloud and hybrid modes require explicit activation.
 - Agent settings UI shells use shared view state for mode options, model provider preferences, LLM provider configuration, privacy impact prompts, approval preferences, and autonomous action limits. Cloud and hybrid activation stays pending until the user confirms the privacy impact summary.
 - LLM provider credentials use secure references such as `env:NAME`, `keychain:name`, `keystore:name`, or `secret:name`. Local providers cannot persist shared credentials, while cloud and custom HTTPS endpoint providers require explicit cloud processing opt-in before use.
@@ -45,7 +46,7 @@ The local Teleton Agent lifecycle has four platform targets:
 
 | Platform | Supported local runtime direction | Packaging gaps |
 | --- | --- | --- |
-| Android | Foreground service or bound service wrapping a bundled agent binary. | Service strategy, ABI-specific binary packaging, update policy, and sandbox-safe IPC still need platform implementation. |
+| Android | App-private foreground service wrapping a bundled agent binary, with WorkManager jobs for sync work. | Kotlin/Jetpack Compose wrapper contract is defined; concrete Gradle sources, ABI-specific binary packaging, update policy, and sandbox-safe IPC still need native implementation. |
 | iOS | App extension or in-app process within iOS background execution limits. | App Store background constraints, signed framework packaging, entitlements, and suspension fallback behavior still need review. |
 | Desktop | Child process supervised by the desktop shell with local IPC. | Per-OS binaries, code signing or notarization, crash restart policy, log paths, and IPC endpoint reservation still need implementation. |
 | Web | Browser worker, WebAssembly runtime, or native-host bridge when available. | Browser support matrix, native-host installation permissions, and fallback behavior for unsupported browsers still need implementation. |
@@ -92,4 +93,4 @@ The view also carries model provider/model id preferences, provider configuratio
 
 ## Foundation Status
 
-This PR implements only the foundation layer, epic decomposition workflow, baseline TDLib adapter boundary, local agent runtime lifecycle contract, agent IPC bridge contract, local agent memory encryption contract, mock-backed TON wallet adapter boundary, and mock-backed TON swap adapter boundary. Platform UI shells, live TDLib integration, concrete agent process packaging, concrete IPC transports, concrete secure storage bindings, and live TON operations remain tracked by the generated subtasks in `config/epic-subtasks.json`.
+This PR implements only the foundation layer, epic decomposition workflow, baseline TDLib adapter boundary, Android wrapper contract, local agent runtime lifecycle contract, agent IPC bridge contract, local agent memory encryption contract, mock-backed TON wallet adapter boundary, and mock-backed TON swap adapter boundary. Native Gradle sources, non-Android platform UI shells, live TDLib integration, concrete agent process packaging, concrete IPC transports, concrete secure storage bindings, and live TON operations remain tracked by the generated subtasks in `config/epic-subtasks.json`.

--- a/src/platform/android-wrapper.mjs
+++ b/src/platform/android-wrapper.mjs
@@ -1,0 +1,432 @@
+export const ANDROID_PACKAGE_NAME = 'dev.teleton.client';
+export const ANDROID_ENTRY_ACTIVITY = `${ANDROID_PACKAGE_NAME}.MainActivity`;
+export const ANDROID_DEEP_LINK_SCHEMES = Object.freeze(['teleton', 'tg', 'ton', 'https']);
+
+export const ANDROID_WRAPPER_STACK = deepFreeze({
+  platform: 'android',
+  language: 'kotlin',
+  uiToolkit: 'jetpack-compose',
+  buildSystem: 'gradle-android-plugin',
+  minSdk: 26,
+  targetSdk: 35,
+  packageName: ANDROID_PACKAGE_NAME,
+  entryActivity: ANDROID_ENTRY_ACTIVITY,
+  sharedIntegrations: ['tdlib', 'settings', 'agent', 'proxy', 'ton']
+});
+
+export const ANDROID_NOTIFICATION_CHANNELS = deepFreeze({
+  messages: {
+    id: 'messages',
+    name: 'Messages',
+    importance: 'default',
+    category: 'message',
+    visibility: 'private',
+    redactedLockScreen: true
+  },
+  agentActions: {
+    id: 'agent_actions',
+    name: 'Agent actions',
+    importance: 'high',
+    category: 'status',
+    visibility: 'private',
+    redactedLockScreen: true
+  },
+  agentRuntime: {
+    id: 'agent_runtime',
+    name: 'Agent runtime',
+    importance: 'low',
+    category: 'service',
+    visibility: 'private',
+    redactedLockScreen: true
+  },
+  wallet: {
+    id: 'wallet',
+    name: 'TON wallet',
+    importance: 'default',
+    category: 'status',
+    visibility: 'private',
+    redactedLockScreen: true
+  }
+});
+
+const ANDROID_BACKGROUND_WORK = deepFreeze({
+  agentRuntime: {
+    api: 'ForegroundService',
+    service: `${ANDROID_PACKAGE_NAME}.agent.TeletonAgentForegroundService`,
+    exported: false,
+    notificationChannelId: ANDROID_NOTIFICATION_CHANNELS.agentRuntime.id,
+    foregroundServiceTypes: ['dataSync'],
+    startPolicy: 'user-initiated-or-notification-action',
+    stopPolicy: 'stopSelf-and-supervisor-shutdown'
+  },
+  messageSync: {
+    api: 'WorkManager',
+    worker: `${ANDROID_PACKAGE_NAME}.sync.MessageSyncWorker`,
+    expedited: true,
+    foregroundInfoRequired: true,
+    notificationChannelId: ANDROID_NOTIFICATION_CHANNELS.messages.id,
+    constraints: {
+      networkType: 'connected'
+    }
+  },
+  tonStatusRefresh: {
+    api: 'WorkManager',
+    worker: `${ANDROID_PACKAGE_NAME}.ton.TonStatusRefreshWorker`,
+    expedited: false,
+    foregroundInfoRequired: false,
+    notificationChannelId: ANDROID_NOTIFICATION_CHANNELS.wallet.id,
+    constraints: {
+      networkType: 'connected',
+      requiresBatteryNotLow: true
+    }
+  }
+});
+
+const DEBUG_ARTIFACT_PATH = 'android/app/build/outputs/apk/debug/app-debug.apk';
+const PRIVATE_NOTIFICATION_FIELDS = new Set([
+  'body',
+  'chatName',
+  'chatTitle',
+  'content',
+  'context',
+  'message',
+  'messageText',
+  'prompt',
+  'recipientName',
+  'senderName',
+  'text'
+]);
+
+function deepFreeze(value) {
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  for (const child of Object.values(value)) {
+    deepFreeze(child);
+  }
+
+  return Object.freeze(value);
+}
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function redactNotificationPayload(value) {
+  if (!isPlainObject(value)) {
+    return {};
+  }
+
+  const redacted = {};
+
+  for (const [key, fieldValue] of Object.entries(value)) {
+    if (PRIVATE_NOTIFICATION_FIELDS.has(key)) {
+      continue;
+    }
+
+    if (Array.isArray(fieldValue)) {
+      redacted[key] = fieldValue.map((entry) => (isPlainObject(entry) ? redactNotificationPayload(entry) : entry));
+    } else if (isPlainObject(fieldValue)) {
+      redacted[key] = redactNotificationPayload(fieldValue);
+    } else {
+      redacted[key] = fieldValue;
+    }
+  }
+
+  return redacted;
+}
+
+function shouldDeliverNotification(notification, settings = {}) {
+  if (notification.requiresUserAction || notification.priority === 'critical') {
+    return true;
+  }
+
+  const notificationSettings = settings.notifications ?? {};
+  if (notificationSettings.enabled === false) {
+    return false;
+  }
+
+  if (notificationSettings.mentionsOnly === true) {
+    return false;
+  }
+
+  return true;
+}
+
+function normalizeNotificationChannel(notification) {
+  if (notification.type?.startsWith('agent.action')) {
+    return ANDROID_NOTIFICATION_CHANNELS.agentActions;
+  }
+
+  if (notification.type?.startsWith('ton.')) {
+    return ANDROID_NOTIFICATION_CHANNELS.wallet;
+  }
+
+  return ANDROID_NOTIFICATION_CHANNELS.messages;
+}
+
+function pendingIntentRouteFor(notification) {
+  if (notification.requiresUserAction || notification.priority === 'critical') {
+    return 'agent.action.review';
+  }
+
+  if (notification.type?.startsWith('ton.')) {
+    return 'ton.wallet.open';
+  }
+
+  return 'messaging.open';
+}
+
+function decodePathSegments(pathname) {
+  return pathname
+    .split('/')
+    .filter(Boolean)
+    .map((segment) => decodeURIComponent(segment));
+}
+
+function acceptedRoute(source, workflow, sharedModule, payload = {}) {
+  return {
+    accepted: true,
+    platform: 'android',
+    source,
+    workflow,
+    sharedModule,
+    payload
+  };
+}
+
+function rejectedRoute(reason, source = 'deep-link') {
+  return {
+    accepted: false,
+    platform: 'android',
+    source,
+    reason
+  };
+}
+
+function routeTelegramLink(url, source) {
+  const host = url.hostname.toLowerCase();
+  const segments = decodePathSegments(url.pathname);
+
+  if (url.protocol === 'tg:' && host === 'resolve') {
+    const username = (url.searchParams.get('domain') ?? '').trim().replace(/^@/, '');
+    if (!username) {
+      return rejectedRoute('missing_telegram_domain', source);
+    }
+
+    const messageId = (url.searchParams.get('post') ?? '').trim();
+    if (messageId) {
+      return acceptedRoute(source, 'messaging.openMessage', 'tdlib', { username, messageId });
+    }
+
+    return acceptedRoute(source, 'messaging.openChat', 'tdlib', { username });
+  }
+
+  if (url.protocol === 'tg:' && host === 'msg') {
+    const text = (url.searchParams.get('text') ?? '').trim();
+    return acceptedRoute(source, 'messaging.composeMessage', 'tdlib', text ? { text } : {});
+  }
+
+  if (url.protocol === 'https:' && ['t.me', 'telegram.me'].includes(host)) {
+    const username = (segments[0] ?? '').trim().replace(/^@/, '');
+    if (!username) {
+      return rejectedRoute('missing_telegram_path', source);
+    }
+
+    if (segments[1]) {
+      return acceptedRoute(source, 'messaging.openMessage', 'tdlib', {
+        username,
+        messageId: segments[1]
+      });
+    }
+
+    return acceptedRoute(source, 'messaging.openChat', 'tdlib', { username });
+  }
+
+  return null;
+}
+
+function routeTonLink(url, source) {
+  const host = url.hostname.toLowerCase();
+  const segments = decodePathSegments(url.pathname);
+
+  if (host === 'transfer') {
+    const recipientAddress = (segments[0] ?? url.searchParams.get('address') ?? url.searchParams.get('to') ?? '').trim();
+    if (!recipientAddress) {
+      return rejectedRoute('missing_ton_recipient', source);
+    }
+
+    const payload = {
+      recipientAddress,
+      requiresConfirmation: true
+    };
+    const amountNano = (url.searchParams.get('amount') ?? '').trim();
+    const comment = (url.searchParams.get('text') ?? url.searchParams.get('comment') ?? '').trim();
+
+    if (amountNano) {
+      payload.amountNano = amountNano;
+    }
+
+    if (comment) {
+      payload.comment = comment;
+    }
+
+    return acceptedRoute(source, 'ton.transfer.review', 'ton', payload);
+  }
+
+  if (host === 'dns' || host === 'resolve') {
+    const name = (segments[0] ?? url.searchParams.get('name') ?? '').trim().toLowerCase();
+    if (!name) {
+      return rejectedRoute('missing_ton_name', source);
+    }
+
+    return acceptedRoute(source, 'ton.dns.resolve', 'ton', { name });
+  }
+
+  return null;
+}
+
+function routeTeletonLink(url, source) {
+  const host = url.hostname.toLowerCase();
+  const segments = decodePathSegments(url.pathname);
+
+  if (host === 'chat') {
+    const chatId = (segments[0] ?? url.searchParams.get('id') ?? '').trim();
+    return chatId
+      ? acceptedRoute(source, 'messaging.openChat', 'tdlib', { chatId })
+      : rejectedRoute('missing_chat_id', source);
+  }
+
+  if (host === 'settings') {
+    return acceptedRoute(source, 'settings.openSection', 'settings', {
+      section: segments[0] ?? 'root'
+    });
+  }
+
+  if (host === 'agent' && segments[0] === 'action') {
+    const actionId = (segments[1] ?? url.searchParams.get('id') ?? '').trim();
+    return actionId
+      ? acceptedRoute(source, 'agent.action.review', 'agent', { actionId })
+      : rejectedRoute('missing_agent_action_id', source);
+  }
+
+  if (host === 'proxy') {
+    return acceptedRoute(source, 'proxy.openSettings', 'proxy', {
+      proxyId: segments[0] ?? null
+    });
+  }
+
+  if (host === 'ton' && segments[0] === 'transfer') {
+    const recipientAddress = (url.searchParams.get('address') ?? url.searchParams.get('to') ?? '').trim();
+    return recipientAddress
+      ? acceptedRoute(source, 'ton.transfer.review', 'ton', { recipientAddress, requiresConfirmation: true })
+      : rejectedRoute('missing_ton_recipient', source);
+  }
+
+  return null;
+}
+
+export function createAndroidDebugBuildArtifact(options = {}) {
+  return {
+    platform: 'android',
+    variant: 'debug',
+    format: 'apk',
+    path: DEBUG_ARTIFACT_PATH,
+    packageName: ANDROID_PACKAGE_NAME,
+    entryActivity: ANDROID_ENTRY_ACTIVITY,
+    buildId: String(options.buildId ?? 'local-debug'),
+    installable: true,
+    runnable: true
+  };
+}
+
+export function describeAndroidBackgroundWork() {
+  return clone(ANDROID_BACKGROUND_WORK);
+}
+
+export function createAndroidNotificationRequest(notification, options = {}) {
+  if (!isPlainObject(notification)) {
+    throw new Error('Android notification request requires a shared notification object.');
+  }
+
+  if (!shouldDeliverNotification(notification, options.settings)) {
+    return null;
+  }
+
+  const channel = normalizeNotificationChannel(notification);
+  const payload = redactNotificationPayload(notification.payload);
+
+  return {
+    platform: 'android',
+    api: 'NotificationCompat',
+    permission: 'android.permission.POST_NOTIFICATIONS',
+    notificationId: String(notification.id ?? `${channel.id}.${Date.now()}`),
+    channelId: channel.id,
+    channelName: channel.name,
+    priority: notification.priority ?? 'normal',
+    category: channel.category,
+    visibility: channel.visibility,
+    title: String(notification.title ?? ''),
+    body: String(notification.body ?? ''),
+    lockScreenBody: String(notification.lockScreenBody ?? ''),
+    foregroundServiceEligible: channel.id === 'agent_runtime' || notification.requiresUserAction === true,
+    pendingIntent: {
+      route: pendingIntentRouteFor(notification),
+      flags: ['FLAG_IMMUTABLE', 'FLAG_UPDATE_CURRENT'],
+      extras: {
+        notificationId: String(notification.id ?? ''),
+        payload
+      }
+    }
+  };
+}
+
+export function routeAndroidDeepLink(input) {
+  let url;
+  try {
+    url = new URL(String(input));
+  } catch {
+    return rejectedRoute('invalid_url');
+  }
+
+  const scheme = url.protocol.replace(/:$/, '').toLowerCase();
+  if (!ANDROID_DEEP_LINK_SCHEMES.includes(scheme)) {
+    return rejectedRoute('unsupported_scheme');
+  }
+
+  const source = scheme === 'https' ? 'app-link' : 'deep-link';
+  const telegramRoute = routeTelegramLink(url, source);
+  if (telegramRoute) {
+    return telegramRoute;
+  }
+
+  if (scheme === 'ton') {
+    return routeTonLink(url, source) ?? rejectedRoute('unsupported_ton_link', source);
+  }
+
+  if (scheme === 'teleton') {
+    return routeTeletonLink(url, source) ?? rejectedRoute('unsupported_teleton_link', source);
+  }
+
+  return rejectedRoute('unsupported_deep_link', source);
+}
+
+export function describeAndroidWrapper() {
+  return {
+    stack: clone(ANDROID_WRAPPER_STACK),
+    debugArtifact: createAndroidDebugBuildArtifact(),
+    notificationChannels: clone(ANDROID_NOTIFICATION_CHANNELS),
+    backgroundWork: describeAndroidBackgroundWork(),
+    deepLinks: {
+      schemes: [...ANDROID_DEEP_LINK_SCHEMES],
+      entryActivity: ANDROID_ENTRY_ACTIVITY,
+      manifestAction: 'android.intent.action.VIEW',
+      categories: ['android.intent.category.DEFAULT', 'android.intent.category.BROWSABLE']
+    }
+  };
+}

--- a/test/android-wrapper.test.mjs
+++ b/test/android-wrapper.test.mjs
@@ -1,0 +1,197 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+
+import { createAgentActionNotification } from '../src/foundation/agent-action-notifications.mjs';
+import {
+  ANDROID_DEEP_LINK_SCHEMES,
+  ANDROID_WRAPPER_STACK,
+  createAndroidDebugBuildArtifact,
+  createAndroidNotificationRequest,
+  describeAndroidBackgroundWork,
+  describeAndroidWrapper,
+  routeAndroidDeepLink
+} from '../src/platform/android-wrapper.mjs';
+
+const root = new URL('../', import.meta.url);
+
+function pathFor(relativePath) {
+  return new URL(relativePath, root);
+}
+
+test('Android wrapper selects a build stack and exposes a runnable debug artifact contract', () => {
+  const wrapper = describeAndroidWrapper();
+  const artifact = createAndroidDebugBuildArtifact({ buildId: 'local-debug-1' });
+
+  assert.equal(ANDROID_WRAPPER_STACK.platform, 'android');
+  assert.equal(wrapper.stack.language, 'kotlin');
+  assert.equal(wrapper.stack.uiToolkit, 'jetpack-compose');
+  assert.equal(wrapper.stack.buildSystem, 'gradle-android-plugin');
+  assert.deepEqual(wrapper.stack.sharedIntegrations, ['tdlib', 'settings', 'agent', 'proxy', 'ton']);
+  assert.equal(wrapper.debugArtifact.path, 'android/app/build/outputs/apk/debug/app-debug.apk');
+  assert.deepEqual(artifact, {
+    platform: 'android',
+    variant: 'debug',
+    format: 'apk',
+    path: 'android/app/build/outputs/apk/debug/app-debug.apk',
+    packageName: 'dev.teleton.client',
+    entryActivity: 'dev.teleton.client.MainActivity',
+    buildId: 'local-debug-1',
+    installable: true,
+    runnable: true
+  });
+});
+
+test('Android notifications map shared events to redacted platform notification channels', () => {
+  const approval = createAgentActionNotification({
+    id: 'agent-approval-1',
+    type: 'agent.action.approvalRequired',
+    action: 'sendMessage',
+    actionLabel: 'Send message',
+    payload: {
+      messageText: 'private message body',
+      chatTitle: 'Private chat'
+    },
+    timestamp: '2026-04-26T12:00:00.000Z'
+  });
+
+  const request = createAndroidNotificationRequest(approval);
+
+  assert.equal(request.channelId, 'agent_actions');
+  assert.equal(request.api, 'NotificationCompat');
+  assert.equal(request.permission, 'android.permission.POST_NOTIFICATIONS');
+  assert.equal(request.priority, 'critical');
+  assert.equal(request.visibility, 'private');
+  assert.equal(request.foregroundServiceEligible, true);
+  assert.equal(request.pendingIntent.route, 'agent.action.review');
+  assert.doesNotMatch(JSON.stringify(request), /private message body|Private chat/);
+
+  const muted = createAgentActionNotification({
+    id: 'agent-info-1',
+    type: 'agent.action.completed',
+    action: 'summarizeChat',
+    actionLabel: 'Summarize chat'
+  });
+
+  assert.equal(createAndroidNotificationRequest(muted, { settings: { notifications: { enabled: false } } }), null);
+});
+
+test('Android background work uses WorkManager and an app-private foreground service boundary', () => {
+  const work = describeAndroidBackgroundWork();
+
+  assert.equal(work.agentRuntime.api, 'ForegroundService');
+  assert.equal(work.agentRuntime.service, 'dev.teleton.client.agent.TeletonAgentForegroundService');
+  assert.equal(work.agentRuntime.exported, false);
+  assert.equal(work.agentRuntime.notificationChannelId, 'agent_runtime');
+  assert.deepEqual(work.agentRuntime.foregroundServiceTypes, ['dataSync']);
+
+  assert.equal(work.messageSync.api, 'WorkManager');
+  assert.equal(work.messageSync.worker, 'dev.teleton.client.sync.MessageSyncWorker');
+  assert.equal(work.messageSync.expedited, true);
+  assert.equal(work.messageSync.foregroundInfoRequired, true);
+
+  assert.equal(work.tonStatusRefresh.api, 'WorkManager');
+  assert.equal(work.tonStatusRefresh.constraints.networkType, 'connected');
+});
+
+test('Android deep links route Telegram and TON URIs to shared workflows', () => {
+  assert.deepEqual(ANDROID_DEEP_LINK_SCHEMES, ['teleton', 'tg', 'ton', 'https']);
+
+  assert.deepEqual(routeAndroidDeepLink('tg://resolve?domain=teleton'), {
+    accepted: true,
+    platform: 'android',
+    source: 'deep-link',
+    workflow: 'messaging.openChat',
+    sharedModule: 'tdlib',
+    payload: {
+      username: 'teleton'
+    }
+  });
+
+  assert.deepEqual(routeAndroidDeepLink('https://t.me/teleton/42'), {
+    accepted: true,
+    platform: 'android',
+    source: 'app-link',
+    workflow: 'messaging.openMessage',
+    sharedModule: 'tdlib',
+    payload: {
+      username: 'teleton',
+      messageId: '42'
+    }
+  });
+
+  assert.deepEqual(routeAndroidDeepLink('ton://transfer/EQExampleAddress?amount=1000&text=coffee'), {
+    accepted: true,
+    platform: 'android',
+    source: 'deep-link',
+    workflow: 'ton.transfer.review',
+    sharedModule: 'ton',
+    payload: {
+      recipientAddress: 'EQExampleAddress',
+      amountNano: '1000',
+      comment: 'coffee',
+      requiresConfirmation: true
+    }
+  });
+
+  assert.deepEqual(routeAndroidDeepLink('ton://dns/example.ton'), {
+    accepted: true,
+    platform: 'android',
+    source: 'deep-link',
+    workflow: 'ton.dns.resolve',
+    sharedModule: 'ton',
+    payload: {
+      name: 'example.ton'
+    }
+  });
+
+  assert.deepEqual(routeAndroidDeepLink('teleton://settings/notifications'), {
+    accepted: true,
+    platform: 'android',
+    source: 'deep-link',
+    workflow: 'settings.openSection',
+    sharedModule: 'settings',
+    payload: {
+      section: 'notifications'
+    }
+  });
+
+  assert.deepEqual(routeAndroidDeepLink('teleton://agent/action/approval-1'), {
+    accepted: true,
+    platform: 'android',
+    source: 'deep-link',
+    workflow: 'agent.action.review',
+    sharedModule: 'agent',
+    payload: {
+      actionId: 'approval-1'
+    }
+  });
+
+  assert.deepEqual(routeAndroidDeepLink('teleton://proxy/proxy-1'), {
+    accepted: true,
+    platform: 'android',
+    source: 'deep-link',
+    workflow: 'proxy.openSettings',
+    sharedModule: 'proxy',
+    payload: {
+      proxyId: 'proxy-1'
+    }
+  });
+});
+
+test('Android wrapper docs cover the selected stack, approved APIs, and deep links', async () => {
+  const readme = await readFile(pathFor('README.md'), 'utf8');
+  const architecture = await readFile(pathFor('docs/architecture.md'), 'utf8');
+  const buildGuide = await readFile(pathFor('BUILD-GUIDE.md'), 'utf8');
+  const androidGuide = await readFile(pathFor('docs/android-wrapper.md'), 'utf8');
+
+  assert.match(readme, /Android wrapper contract/i);
+  assert.match(architecture, /Android wrapper/i);
+  assert.match(buildGuide, /android\/app\/build\/outputs\/apk\/debug\/app-debug\.apk/i);
+  assert.match(androidGuide, /Jetpack Compose/i);
+  assert.match(androidGuide, /WorkManager/i);
+  assert.match(androidGuide, /ForegroundService/i);
+  assert.match(androidGuide, /POST_NOTIFICATIONS/i);
+  assert.match(androidGuide, /tg:\/\/resolve/i);
+  assert.match(androidGuide, /ton:\/\/transfer/i);
+});


### PR DESCRIPTION
## Summary

- Adds a dependency-free Android wrapper contract selecting Kotlin, Jetpack Compose, and the Gradle Android Plugin stack.
- Exposes runnable debug APK artifact metadata for `android/app/build/outputs/apk/debug/app-debug.apk` and the `dev.teleton.client.MainActivity` entry point.
- Maps shared notifications and background work to Android notification channels, `NotificationCompat`, `POST_NOTIFICATIONS`, WorkManager, and an app-private foreground service boundary.
- Routes Telegram, TON, settings, agent, and proxy deep links into shared workflows, with TON transfers always requiring review confirmation.
- Documents the Android wrapper contract in `docs/android-wrapper.md`, `BUILD-GUIDE.md`, `README.md`, and `docs/architecture.md`.

## Issue

Fixes #19

## Reproduction And Verification

Before the implementation, `node --test test/android-wrapper.test.mjs` failed with `ERR_MODULE_NOT_FOUND` because there was no Android wrapper module or documentation. The new test now verifies the debug artifact contract, platform-approved notification/background mappings, and deep-link routing for Telegram, TON, settings, agent, and proxy workflows.

## Tests

- [x] `node --test test/android-wrapper.test.mjs`
- [x] `npm test`
- [x] `npm run validate:foundation`
- [x] `npm run validate:release`
- [x] `npm run decompose:dry-run`
- [x] `git diff --check origin/main...HEAD`

## Risk

This PR adds the foundation-level Android wrapper contract, not concrete native Gradle source files. The docs call out that native Gradle sources, ABI packaging, and sandbox-safe IPC remain follow-up implementation work.

## Screenshots or recordings

Not applicable. This is a platform contract and documentation change with no rendered UI.

## Security and privacy

- [x] This PR does not include secrets, production credentials, access tokens, Telegram API hashes, private keys, or private message content.
- [x] Any logs, screenshots, or fixtures are redacted.