### PR TITLE
Add security audit secret scanning

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,6 +2,7 @@
 set -eu
 
 npm test
+npm run validate:secrets
 npm run validate:foundation
 npm run validate:release
 npm run decompose:dry-run

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,3 +24,4 @@ Add before and after screenshots for UI changes, or write `Not applicable`.
 
 - [ ] This PR does not include secrets, production credentials, access tokens, Telegram API hashes, private keys, or private message content.
 - [ ] Any logs, screenshots, or fixtures are redacted.
+- [ ] Security-sensitive changes request human maintainer review before release.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Run unit tests
         run: npm test
 
+      - name: Scan committed files for secrets
+        run: npm run validate:secrets
+
       - name: Validate foundation artifacts
         run: npm run validate:foundation
 

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-26T19:06:43.636Z for PR creation at branch issue-23-a2007413b713 for issue https://github.com/xlabtg/Teleton-Client/issues/23

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-26T19:06:43.636Z for PR creation at branch issue-23-a2007413b713 for issue https://github.com/xlabtg/Teleton-Client/issues/23

--- a/BUILD-GUIDE.md
+++ b/BUILD-GUIDE.md
@@ -81,6 +81,7 @@ Run the same checks used by CI:
 
 ```sh
 npm test
+npm run validate:secrets
 npm run validate:foundation
 npm run validate:release
 npm run decompose:dry-run
@@ -125,6 +126,10 @@ node scripts/decompose-epic.mjs --create --skip-label-create --repo xlabtg/Telet
 ## Environment
 
 Do not hardcode Telegram API credentials, proxy secrets, TON wallet secrets, cloud model tokens, or agent keys in source files. Use environment variables or platform secure storage references such as `env:TELETON_MTPROTO_SECRET`, `keychain:teleton-agent-token`, or `keystore:ton-wallet`.
+
+Run `npm run validate:secrets` to scan git-tracked files for high-confidence secret patterns before committing or opening a pull request. The command redacts suspected values in output and allows only narrow synthetic fixtures used by redaction tests.
+
+Use `docs/security-audit.md` as the credential inventory and rotation source of truth. It records Telegram, proxy, LLM provider, TON, agent memory, settings sync, and CI credential handling; platform secure storage review requirements; and the human security review required before release.
 
 ## TON Testnet Checks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ Start with:
 
 ```sh
 npm test
+npm run validate:secrets
 npm run validate:foundation
 npm run validate:release
 npm run decompose:dry-run
@@ -50,6 +51,7 @@ Run the same checks used by CI before opening a pull request and again before as
 
 ```sh
 npm test
+npm run validate:secrets
 npm run validate:foundation
 npm run validate:release
 npm run decompose:dry-run
@@ -65,6 +67,8 @@ Represent sensitive runtime values through environment variables or secure stora
 
 Public issues, pull requests, screenshots, fixtures, and logs must be redacted before sharing. Report vulnerabilities through GitHub private security advisories instead of public issues.
 
+Run `npm run validate:secrets` before publishing a branch. The scan rejects high-confidence secret patterns in committed files and redacts findings in command output. Credential inventory, rotation, secure storage review requirements, and release review steps are documented in `docs/security-audit.md`.
+
 Security, privacy, CI, release automation, package metadata, shared client code, and CODEOWNERS changes require human maintainer review according to `.github/CODEOWNERS`.
 
 ## Project Documentation
@@ -74,6 +78,7 @@ Use these documents as the source of truth for foundation work:
 - `README.md` for the current repository status and quick start.
 - `BUILD-GUIDE.md` for local checks, release metadata, and build expectations.
 - `PRIVACY.md` for data handling principles and security reporting.
+- `docs/security-audit.md` for secret scanning, credential rotation, and secure storage review requirements.
 - `docs/architecture.md` for planned layers and integration boundaries.
 - `docs/tdlib-adapter.md` for TDLib adapter and credential handling rules.
 - `docs/release-strategy.md` for release metadata policy.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ This repository is in the foundation phase. The current implementation establish
 - Teleton Agent plugin registry contract with manifest permissions, enable/disable/list/health bridge flows, and lifecycle permission gates.
 - Local Teleton Agent memory encryption contract using platform secure storage key providers, AES-256-GCM payloads, migration, missing-key, locked-store, and key-rotation tests.
 - CI workflow for foundation checks.
+- Automated committed-secret scanning with documented credential rotation and secure storage review requirements.
 - Documented semantic version source of truth and release metadata validation.
 - Required project documents: `README.md`, `PRIVACY.md`, `LICENSE`, and `BUILD-GUIDE.md`.
 
@@ -46,6 +47,7 @@ This repository is in the foundation phase. The current implementation establish
 
 ```sh
 npm test
+npm run validate:secrets
 npm run validate:foundation
 npm run validate:release
 npm run decompose:dry-run
@@ -67,7 +69,7 @@ The project is intended to evolve through these layers:
 4. TON blockchain integrations for wallet, transfers, swaps, NFTs, staking, and DNS.
 5. Security and privacy controls for credentials, user consent, and auditability.
 
-See `docs/architecture.md`, `docs/backlog.md`, `docs/tdlib-adapter.md`, `docs/android-wrapper.md`, `docs/ios-wrapper.md`, `docs/desktop-wrapper.md`, `docs/tablet-layout.md`, `docs/web-pwa-wrapper.md`, and `docs/release-strategy.md` for the current foundation plan. The agent settings, local runtime, input action map, Android wrapper, iOS wrapper, desktop wrapper, tablet layout, and PWA sections record the shared settings UI contract, supported runtime directions, platform execution boundaries, shortcut and gesture behavior, responsive tablet behavior, web installability behavior, and remaining packaging gaps for Android, iOS, desktop, and web wrappers.
+See `docs/architecture.md`, `docs/backlog.md`, `docs/tdlib-adapter.md`, `docs/android-wrapper.md`, `docs/ios-wrapper.md`, `docs/desktop-wrapper.md`, `docs/tablet-layout.md`, `docs/web-pwa-wrapper.md`, `docs/security-audit.md`, and `docs/release-strategy.md` for the current foundation plan. The agent settings, local runtime, input action map, Android wrapper, iOS wrapper, desktop wrapper, tablet layout, PWA, and security audit sections record the shared settings UI contract, supported runtime directions, platform execution boundaries, shortcut and gesture behavior, responsive tablet behavior, web installability behavior, credential rotation expectations, secure storage review requirements, and remaining packaging gaps for Android, iOS, desktop, and web wrappers.
 
 ## Contribution Templates
 

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -1,0 +1,63 @@
+# Security Audit
+
+This audit records the current token, key, rotation, and secure storage requirements for the foundation repository. The current codebase has no production client, native secure storage implementation, or live service credentials; shared code must keep sensitive values behind secure references until platform wrappers resolve them locally.
+
+## Automated Secret Scan
+
+Run the repository secret scan locally and in CI:
+
+```sh
+npm run validate:secrets
+```
+
+The scan reads git-tracked text files and rejects high-confidence committed secret patterns, including private key blocks, Telegram `api_id` or `api_hash` assignments, Telegram bot tokens, GitHub tokens, Slack tokens, OpenAI keys, AWS access key ids, Google API keys, and npm tokens. Findings are redacted in command output so CI logs do not repeat the suspected secret value.
+
+The only allowlisted matches are synthetic fixtures in redaction tests. New allowlist entries require a narrow file path, pattern id, line marker, and human maintainer review.
+
+## Credential Inventory
+
+| Credential source | Current owner boundary | Required storage | Rotation trigger |
+| --- | --- | --- | --- |
+| Telegram API credentials, including `api_id`, `api_hash`, phone numbers, and bot tokens | `src/tdlib/client-adapter.mjs` accepts references only; native TDLib bridges resolve them. | Environment variables, Keychain, Keystore, secret manager, or equivalent platform secure storage. | Leak suspicion, offboarding, vendor policy change, app registration replacement, or release security review finding. |
+| MTProto, SOCKS5, and HTTP CONNECT proxy credentials | Proxy settings models and TDLib proxy commands store only `secretRef`, `usernameRef`, and `passwordRef`. | Environment variables, Keychain, Keystore, or user-managed secret entries. | Proxy provider change, failed access review, suspicious proxy test logs, or shared-device transfer. |
+| LLM provider API keys and bearer tokens | Agent provider configuration requires `apiKeyRef` or `tokenRef` for cloud and custom providers. | Keychain, Keystore, environment variables, or managed secret references resolved outside shared settings. | Provider key rotation policy, cloud-mode disablement, compromised endpoint, or maintainer offboarding. |
+| TON wallet private keys, mnemonics, and provider credentials | TON adapters reject private key fields and accept wallet provider or secure storage references only. | Wallet provider, hardware wallet, platform secure storage, or protected CI secret for testnet-only references. | Wallet provider change, testnet provider replacement, compromise suspicion, or release-blocking financial review. |
+| Agent memory encryption keys | `src/foundation/agent-memory-store.mjs` creates or reads AES-256-GCM data keys from platform secure storage. | iOS Keychain, Android Keystore, desktop OS credential vault, or browser non-extractable WebCrypto-backed storage where available. | Device reenrollment, locked or missing key recovery, storage migration, or release security review. |
+| Settings sync encryption keys | Settings sync stores only local key references and excludes sync key material from payloads. | Device-local secure storage; each device resolves its own key. | Device removal, sync transport replacement, missing-key recovery, or suspected remote snapshot exposure. |
+| GitHub and CI tokens | GitHub Actions uses platform-provided tokens for validation and changelog preview. | GitHub protected repository or environment secrets; never committed files. | Maintainer offboarding, repository permission changes, failed CI audit, or GitHub security alert. |
+
+## Credential Rotation
+
+Use this sequence for every credential class:
+
+1. Create the replacement credential outside the repository.
+2. Store it in the platform secure storage location or protected CI secret that backs the existing reference name, or add a new reviewed reference name.
+3. Deploy or run the affected platform bridge so it resolves the new value without logging it.
+4. Run `npm run validate:secrets`, `npm test`, and the affected integration check.
+5. Revoke or delete the old credential at the provider.
+6. Review recent CI logs, issue comments, pull request text, screenshots, and fixtures for accidental disclosure.
+7. Record the rotation date, credential class, reference name, and reviewer in the private security record. Do not record the secret value.
+
+Telegram app credentials should be replaced through the Telegram developer account or vendor-approved app registration process, then updated behind `apiIdRef` and `apiHashRef`. LLM, proxy, TON, and CI credentials should follow the provider's revocation flow and preserve the same shared reference shape whenever possible so settings snapshots do not need plaintext migration.
+
+## Secure Storage Review
+
+| Platform | Required secure storage behavior | Current review status |
+| --- | --- | --- |
+| Android | Resolve references through Android Keystore or app-private encrypted storage; never return raw values to shared logs or settings exports. | Wrapper contract only; native Keystore binding must be reviewed before release. |
+| iOS | Use Keychain Services with device-local accessibility for TDLib, proxy, agent, sync, and TON references. | Wrapper contract documents Keychain references; concrete Xcode implementation must be reviewed before release. |
+| Desktop | Use the OS credential vault through a native bridge, such as Keychain on macOS, Credential Manager on Windows, or Secret Service/libsecret on Linux. | Electron wrapper contract only; native credential bridge and IPC redaction need review before release. |
+| Web | Prefer no long-lived secrets in browser storage. When a browser-only fallback is unavoidable, use non-extractable WebCrypto keys with IndexedDB metadata and require reauthentication when secure storage is unavailable. | PWA contract documents progressive fallback limits; browser storage hardening must be reviewed before release. |
+| CI | Keep live secrets out of pull_request jobs from forks and resolve testnet-only references only in protected environments. | Current foundation CI does not require live secrets; future live jobs must be reviewed before enablement. |
+
+Release enablement is blocked until a human security review confirms that each platform implementation resolves references locally, redacts diagnostics, supports rotation or reenrollment, and keeps exported settings free of raw credential material.
+
+## Human Security Review
+
+Security and privacy changes require CODEOWNERS review by a human maintainer. Before release, request a human security review that covers:
+
+- The latest `npm run validate:secrets`, `npm test`, `npm run validate:foundation`, and `npm run validate:release` results.
+- Any changes to secret patterns or allowlisted fixtures.
+- Platform secure storage bindings and diagnostic redaction behavior.
+- Credential rotation notes for Telegram, proxy, LLM provider, TON, agent memory, sync, and CI credentials.
+- Confirmation that release notes, screenshots, fixtures, logs, and pull request text do not include secrets or private message content.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "node --test test/*.test.mjs",
     "prepare:hooks": "git config core.hooksPath .githooks",
+    "validate:secrets": "node scripts/validate-secrets.mjs",
     "validate:foundation": "node scripts/validate-foundation.mjs",
     "validate:release": "node scripts/validate-release.mjs",
     "changelog": "node scripts/generate-changelog.mjs",

--- a/scripts/validate-foundation.mjs
+++ b/scripts/validate-foundation.mjs
@@ -23,10 +23,14 @@ const requiredFiles = [
   'docs/contributing-templates.md',
   'docs/architecture.md',
   'docs/release-strategy.md',
+  'docs/security-audit.md',
   'docs/backlog.md',
   'docs/tdlib-adapter.md',
+  'src/foundation/secret-audit.mjs',
   'src/foundation/agent-runtime-supervisor.mjs',
   'test/agent-runtime-supervisor.test.mjs',
+  'scripts/validate-secrets.mjs',
+  'test/secret-audit.test.mjs',
   'src/foundation/agent-action-history.mjs',
   'test/agent-action-history.test.mjs',
   'src/foundation/agent-plugin-registry.mjs',
@@ -120,6 +124,7 @@ for (const subtask of manifest.subtasks) {
 const contributing = await readFile(new URL('CONTRIBUTING.md', root), 'utf8');
 const requiredContributingPatterns = [
   /npm test/,
+  /npm run validate:secrets/,
   /npm run validate:foundation/,
   /npm run validate:release/,
   /npm run decompose:dry-run/,
@@ -136,12 +141,46 @@ for (const pattern of requiredContributingPatterns) {
   assert.match(contributing, pattern, `CONTRIBUTING.md must include ${pattern}`);
 }
 
+const packageJson = JSON.parse(await readFile(new URL('package.json', root), 'utf8'));
+assert.equal(
+  packageJson.scripts['validate:secrets'],
+  'node scripts/validate-secrets.mjs',
+  'package.json must expose the secret validation command'
+);
+
+const preCommitHook = await readFile(new URL('.githooks/pre-commit', root), 'utf8');
+assert.match(preCommitHook, /npm run validate:secrets/, 'pre-commit hook must run the secret scan');
+
+const ciWorkflow = await readFile(new URL('.github/workflows/ci.yml', root), 'utf8');
+assert.match(ciWorkflow, /npm run validate:secrets/, 'CI must run the secret scan');
+
+const securityAudit = await readFile(new URL('docs/security-audit.md', root), 'utf8');
+const requiredSecurityAuditPatterns = [
+  /npm run validate:secrets/,
+  /Credential Inventory/i,
+  /Credential Rotation/i,
+  /Secure Storage Review/i,
+  /Human Security Review/i,
+  /before release/i,
+  /Telegram API credentials/i,
+  /MTProto, SOCKS5, and HTTP CONNECT proxy credentials/i,
+  /LLM provider API keys/i,
+  /TON wallet private keys/i,
+  /Agent memory encryption keys/i,
+  /Settings sync encryption keys/i
+];
+
+for (const pattern of requiredSecurityAuditPatterns) {
+  assert.match(securityAudit, pattern, `docs/security-audit.md must include ${pattern}`);
+}
+
 const docsToScan = [
   'README.md',
   'CONTRIBUTING.md',
   'PRIVACY.md',
   'BUILD-GUIDE.md',
   'docs/architecture.md',
+  'docs/security-audit.md',
   'docs/tdlib-adapter.md'
 ];
 const forbiddenPatterns = [

--- a/scripts/validate-secrets.mjs
+++ b/scripts/validate-secrets.mjs
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import { formatSecretAuditFindings, scanRepositoryForSecrets } from '../src/foundation/secret-audit.mjs';
+
+const result = await scanRepositoryForSecrets();
+
+if (result.findings.length > 0) {
+  console.error(formatSecretAuditFindings(result.findings));
+  process.exitCode = 1;
+} else {
+  console.log(`Secret validation passed for ${result.scannedFileCount} tracked files.`);
+}

--- a/src/foundation/secret-audit.mjs
+++ b/src/foundation/secret-audit.mjs
@@ -1,0 +1,258 @@
+import { execFile } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const defaultRoot = new URL('../../', import.meta.url);
+
+export const SECRET_AUDIT_PATTERNS = Object.freeze([
+  {
+    id: 'private-key-block',
+    description: 'PEM private key block',
+    pattern: /-----BEGIN (?:[A-Z0-9 ]+ )?PRIVATE KEY-----/i
+  },
+  {
+    id: 'telegram-api-id',
+    description: 'Telegram api_id assignment',
+    pattern: /\b(?:api_id|apiId)\s*[:=]\s*['"]?\d{6,}['"]?/i
+  },
+  {
+    id: 'telegram-api-hash',
+    description: 'Telegram api_hash assignment',
+    pattern: /\b(?:api_hash|apiHash)\s*[:=]\s*['"][a-f0-9]{32}['"]/i
+  },
+  {
+    id: 'telegram-bot-token',
+    description: 'Telegram bot token',
+    pattern: /\b\d{6,12}:[A-Za-z0-9_-]{30,}\b/
+  },
+  {
+    id: 'github-token',
+    description: 'GitHub access token',
+    pattern: /\bgh(?:p|o|u|s|r)_[A-Za-z0-9_]{36,255}\b/
+  },
+  {
+    id: 'slack-token',
+    description: 'Slack token',
+    pattern: /\bxox(?:b|p|a|r|s)-[A-Za-z0-9-]{10,}\b/i
+  },
+  {
+    id: 'openai-api-key',
+    description: 'OpenAI API key',
+    pattern: /\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b/
+  },
+  {
+    id: 'aws-access-key-id',
+    description: 'AWS access key id',
+    pattern: /\bA[KS]IA[0-9A-Z]{16}\b/
+  },
+  {
+    id: 'google-api-key',
+    description: 'Google API key',
+    pattern: /\bAIza[0-9A-Za-z_-]{35}\b/
+  },
+  {
+    id: 'npm-token',
+    description: 'npm access token',
+    pattern: /\bnpm_[A-Za-z0-9]{36,}\b/
+  }
+]);
+
+export const SECRET_AUDIT_ALLOWED_FIXTURES = Object.freeze([
+  {
+    filePath: 'test/changelog.test.mjs',
+    patternId: 'github-token',
+    lineIncludes: 'Remove leaked ghp_',
+    reason: 'Synthetic GitHub token used to test changelog redaction.'
+  },
+  {
+    filePath: 'test/tdlib-adapter.test.mjs',
+    patternId: 'telegram-bot-token',
+    lineIncludes: 'network timeout for +1 555 123 4567 token ',
+    reason: 'Synthetic Telegram-like token used to test network error redaction.'
+  },
+  {
+    filePath: 'test/tdlib-adapter.test.mjs',
+    patternId: 'telegram-bot-token',
+    lineIncludes: '/private message body|\\+1 555 123 4567|',
+    reason: 'Synthetic Telegram-like token used in a redaction assertion.'
+  },
+  {
+    filePath: 'test/network-error-logger.test.mjs',
+    patternId: 'telegram-bot-token',
+    lineIncludes: "botToken: '123456:",
+    reason: 'Synthetic Telegram-like token used to test network log redaction.'
+  }
+]);
+
+const IGNORED_DIRECTORIES = Object.freeze([
+  '.git/',
+  '.next/',
+  '.turbo/',
+  'build/',
+  'ci-logs/',
+  'coverage/',
+  'dist/',
+  'node_modules/',
+  'out/'
+]);
+
+const BINARY_EXTENSIONS = Object.freeze(
+  new Set([
+    '.7z',
+    '.apk',
+    '.avif',
+    '.bin',
+    '.bmp',
+    '.class',
+    '.dmg',
+    '.exe',
+    '.gif',
+    '.gz',
+    '.ico',
+    '.jar',
+    '.jpeg',
+    '.jpg',
+    '.keystore',
+    '.mov',
+    '.mp4',
+    '.pdf',
+    '.png',
+    '.so',
+    '.tar',
+    '.tgz',
+    '.ttf',
+    '.webm',
+    '.webp',
+    '.woff',
+    '.woff2',
+    '.zip'
+  ])
+);
+
+function rootToPath(root) {
+  return root instanceof URL ? fileURLToPath(root) : String(root);
+}
+
+function normalizeRelativePath(filePath) {
+  return String(filePath).replaceAll(path.sep, '/').replace(/^\.\//, '');
+}
+
+function toGlobalRegExp(pattern) {
+  const flags = pattern.flags.includes('g') ? pattern.flags : `${pattern.flags}g`;
+  return new RegExp(pattern.source, flags);
+}
+
+function shouldScanFile(filePath) {
+  const normalized = normalizeRelativePath(filePath);
+
+  if (!normalized || IGNORED_DIRECTORIES.some((directory) => normalized.startsWith(directory))) {
+    return false;
+  }
+
+  return !BINARY_EXTENSIONS.has(path.extname(normalized).toLowerCase());
+}
+
+function isAllowedFinding({ filePath, line, patternId }, allowlist) {
+  return allowlist.some((rule) => {
+    if (rule.patternId !== patternId) {
+      return false;
+    }
+
+    if (normalizeRelativePath(rule.filePath) !== normalizeRelativePath(filePath)) {
+      return false;
+    }
+
+    return rule.lineIncludes === undefined || line.includes(rule.lineIncludes);
+  });
+}
+
+function redactSnippet(line, start, end) {
+  const prefix = line.slice(Math.max(0, start - 40), start);
+  const suffix = line.slice(end, Math.min(line.length, end + 40));
+
+  return `${prefix}[secret-like-value]${suffix}`.trim();
+}
+
+async function listGitTrackedFiles(rootPath) {
+  const { stdout } = await execFileAsync('git', ['ls-files', '-z'], {
+    cwd: rootPath,
+    maxBuffer: 10 * 1024 * 1024
+  });
+
+  return stdout.split('\0').filter(Boolean);
+}
+
+export function scanTextForSecrets(content, { filePath = '(inline)', allowlist = SECRET_AUDIT_ALLOWED_FIXTURES } = {}) {
+  const findings = [];
+  const lines = String(content).split(/\r?\n/);
+
+  for (const [lineIndex, line] of lines.entries()) {
+    for (const { id, description, pattern } of SECRET_AUDIT_PATTERNS) {
+      for (const match of line.matchAll(toGlobalRegExp(pattern))) {
+        const column = match.index + 1;
+        const end = match.index + match[0].length;
+
+        if (isAllowedFinding({ filePath, line, patternId: id }, allowlist)) {
+          continue;
+        }
+
+        findings.push({
+          filePath: normalizeRelativePath(filePath),
+          lineNumber: lineIndex + 1,
+          column,
+          patternId: id,
+          description,
+          snippet: redactSnippet(line, match.index, end)
+        });
+      }
+    }
+  }
+
+  return findings;
+}
+
+export async function scanRepositoryForSecrets({
+  root = defaultRoot,
+  files,
+  allowlist = SECRET_AUDIT_ALLOWED_FIXTURES
+} = {}) {
+  const rootPath = rootToPath(root);
+  const trackedFiles = files ?? (await listGitTrackedFiles(rootPath));
+  const scannedFiles = [];
+  const findings = [];
+
+  for (const file of trackedFiles) {
+    const relativePath = normalizeRelativePath(file);
+
+    if (!shouldScanFile(relativePath)) {
+      continue;
+    }
+
+    const content = await readFile(path.join(rootPath, relativePath), 'utf8');
+    scannedFiles.push(relativePath);
+    findings.push(...scanTextForSecrets(content, { filePath: relativePath, allowlist }));
+  }
+
+  return {
+    findings,
+    scannedFiles,
+    scannedFileCount: scannedFiles.length
+  };
+}
+
+export function formatSecretAuditFindings(findings) {
+  if (findings.length === 0) {
+    return 'No secret-like values found.';
+  }
+
+  return [
+    `Secret audit found ${findings.length} unapproved secret-like value(s):`,
+    ...findings.map(
+      (finding) =>
+        `- ${finding.filePath}:${finding.lineNumber}:${finding.column} ${finding.patternId} (${finding.description}) ${finding.snippet}`
+    )
+  ].join('\n');
+}

--- a/test/foundation.test.mjs
+++ b/test/foundation.test.mjs
@@ -30,6 +30,7 @@ test('foundation artifacts required by issue 1 are present', () => {
     '.github/pull_request_template.md',
     'config/epic-subtasks.json',
     'docs/release-strategy.md',
+    'docs/security-audit.md',
     'docs/contributing-templates.md',
     'docs/tdlib-adapter.md'
   ];
@@ -100,9 +101,33 @@ test('pre-commit hook is installable and runs deterministic local checks', async
   const hook = await readFile(hookPath, 'utf8');
   assert.match(hook, /^#!\/usr\/bin\/env sh\n/, 'pre-commit hook should be directly executable');
   assert.match(hook, /npm test/, 'pre-commit hook should run the test suite');
+  assert.match(hook, /npm run validate:secrets/, 'pre-commit hook should run the secret scan');
   assert.match(hook, /npm run validate:foundation/, 'pre-commit hook should run foundation validation');
   assert.match(hook, /npm run validate:release/, 'pre-commit hook should run release metadata validation');
   assert.match(hook, /npm run decompose:dry-run/, 'pre-commit hook should run the deterministic dry run');
+});
+
+test('security audit documents scanning, rotation, secure storage, and human review', async () => {
+  const audit = await readFile(pathFor('docs/security-audit.md'), 'utf8');
+  const contributing = await readFile(pathFor('CONTRIBUTING.md'), 'utf8');
+  const buildGuide = await readFile(pathFor('BUILD-GUIDE.md'), 'utf8');
+  const ci = await readFile(pathFor('.github/workflows/ci.yml'), 'utf8');
+
+  assert.match(audit, /npm run validate:secrets/);
+  assert.match(audit, /Credential Inventory/i);
+  assert.match(audit, /Credential Rotation/i);
+  assert.match(audit, /Secure Storage Review/i);
+  assert.match(audit, /Human Security Review/i);
+  assert.match(audit, /before release/i);
+  assert.match(audit, /Telegram API credentials/i);
+  assert.match(audit, /MTProto, SOCKS5, and HTTP CONNECT proxy credentials/i);
+  assert.match(audit, /LLM provider API keys/i);
+  assert.match(audit, /TON wallet private keys/i);
+  assert.match(audit, /Agent memory encryption keys/i);
+  assert.match(audit, /Settings sync encryption keys/i);
+  assert.match(contributing, /docs\/security-audit\.md/);
+  assert.match(buildGuide, /Credential Inventory/i);
+  assert.match(ci, /npm run validate:secrets/);
 });
 
 test('epic backlog decomposes issue 1 into prioritized phases', async () => {

--- a/test/secret-audit.test.mjs
+++ b/test/secret-audit.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+
+import {
+  formatSecretAuditFindings,
+  scanRepositoryForSecrets,
+  scanTextForSecrets
+} from '../src/foundation/secret-audit.mjs';
+
+const root = new URL('../', import.meta.url);
+
+function pathFor(relativePath) {
+  return new URL(relativePath, root);
+}
+
+test('secret audit detects high-confidence committed credential patterns', () => {
+  const githubToken = 'ghp_' + 'a'.repeat(36);
+  const telegramApiHash = 'b'.repeat(32);
+  const botToken = '123456789:' + 'A'.repeat(35);
+  const content = [
+    `GITHUB_TOKEN=${githubToken}`,
+    `api_hash = "${telegramApiHash}"`,
+    `botToken: "${botToken}"`
+  ].join('\n');
+
+  const findings = scanTextForSecrets(content, {
+    filePath: 'sample.env',
+    allowlist: []
+  });
+
+  assert.deepEqual(
+    findings.map((finding) => finding.patternId),
+    ['github-token', 'telegram-api-hash', 'telegram-bot-token']
+  );
+
+  const formatted = formatSecretAuditFindings(findings);
+  assert.match(formatted, /\[secret-like-value\]/);
+  assert.doesNotMatch(formatted, new RegExp(githubToken));
+  assert.doesNotMatch(formatted, new RegExp(telegramApiHash));
+  assert.doesNotMatch(formatted, new RegExp(botToken));
+});
+
+test('secret audit accepts secure references and scans committed files', async () => {
+  const safeContent = [
+    'apiHashRef: "keychain:telegram-api-hash"',
+    'tokenRef: "secret:approved-custom-token"',
+    'secretRef: "env:TELETON_MTPROTO_SECRET"'
+  ].join('\n');
+
+  assert.deepEqual(scanTextForSecrets(safeContent, { filePath: 'safe.mjs' }), []);
+
+  const result = await scanRepositoryForSecrets({ root });
+
+  assert.deepEqual(result.findings, []);
+  assert.ok(result.scannedFileCount > 0);
+});
+
+test('security audit documentation records credential rotation and release review requirements', async () => {
+  const audit = await readFile(pathFor('docs/security-audit.md'), 'utf8');
+
+  assert.match(audit, /npm run validate:secrets/);
+  assert.match(audit, /Credential rotation/i);
+  assert.match(audit, /Telegram API/i);
+  assert.match(audit, /Human security review/i);
+  assert.match(audit, /before release/i);
+});


### PR DESCRIPTION
## Summary

- Add a dependency-free secret audit scanner for high-confidence committed credential patterns.
- Wire `npm run validate:secrets` into CI, pre-commit, docs, and foundation validation.
- Document credential inventory, rotation steps, platform secure storage review requirements, and human security review before release.

## Issue

Fixes #23

## Tests

- [x] `npm test`
- [x] `npm run validate:secrets`
- [x] `npm run validate:foundation`
- [x] `npm run validate:release`
- [x] `npm run decompose:dry-run`
- [x] Manual checks, if relevant: reviewed staged diff and confirmed `git diff --cached --check` passes

## Risk

- Secret scanning uses high-confidence patterns to reduce false positives. Existing redaction fixtures are allowlisted only by exact file, pattern id, and line marker.
- Native secure storage remains a documented release blocker until platform implementations exist and receive human security review.

## Screenshots or recordings

Not applicable.

## Security and privacy

- [x] This PR does not include secrets, production credentials, access tokens, Telegram API hashes, private keys, or private message content.
- [x] Any logs, screenshots, or fixtures are redacted.
- [x] Security-sensitive changes request human maintainer review before release.
