### PR TITLE
[052] Publish privacy policy for local processing and data flows

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-26T19:45:32.097Z for PR creation at branch issue-25-74ae3f65b937 for issue https://github.com/xlabtg/Teleton-Client/issues/25

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-26T19:45:32.097Z for PR creation at branch issue-25-74ae3f65b937 for issue https://github.com/xlabtg/Teleton-Client/issues/25

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,28 +1,59 @@
-# Privacy Policy Draft
+# Privacy Policy
 
-Teleton Client is designed around explicit user control for Telegram-compatible messaging, Teleton Agent automation, proxy connectivity, and TON blockchain operations.
+Teleton Client is designed around explicit user control for Telegram-compatible messaging, Teleton Agent automation, proxy connectivity, optional cloud processing, settings synchronization, and TON blockchain operations.
 
 ## Current Repository State
 
-This repository currently contains foundation automation, configuration models, documentation, and tests. It does not yet ship a production client, collect telemetry, connect to Telegram, run an AI agent, or submit TON transactions.
+This repository currently contains foundation automation, configuration models, documentation, and tests. It does not yet ship a production client, collect telemetry, connect to Telegram, run an AI agent, synchronize settings, query TON services, or submit TON transactions.
 
 ## Data Handling Principles
 
-- Chat data must remain local unless the user explicitly enables cloud or hybrid agent mode.
+- Private message content, prompts, agent memory, wallet data, and credentials stay local by default.
+- Chat data must remain local unless the user explicitly enables settings synchronization or a cloud-capable agent mode that needs selected context.
 - AI models must not be trained on private chat content by default.
-- Autonomous agent actions must require clear user consent and configurable limits.
+- Autonomous agent actions must require clear user consent, configurable limits, reviewable history, and approval gates for sensitive actions.
 - LLM provider credentials must be stored as secure references such as `env:NAME`, `keychain:name`, `keystore:name`, or `secret:name`; raw API keys and tokens must not be committed to settings, logs, issues, or pull requests.
-- Proxy credentials and MTProto secrets must be represented by secure references, not hardcoded values.
+- Telegram, proxy, sync, and TON credentials must be represented by secure references, not hardcoded values.
 - Settings synchronization is opt-in and disabled by default. Sync payloads exclude secure references, proxy credentials, cloud provider credential references, local security controls, and private agent memory.
 - TON private keys and wallet credentials must use platform secure storage or user-approved wallet providers.
 
-## Planned Data Flows
+## Data Flow Coverage
 
-Telegram traffic will be handled through TDLib and optional user-configured proxies. Agent traffic will use a local IPC bridge by default, with cloud processing available only through an explicit setting. TON operations will use TON SDK or wallet-provider integrations and require confirmation for transactions.
+### Telegram Messaging
 
-Agent provider configuration supports local runtimes, approved cloud providers, and approved custom HTTPS endpoints. Local providers keep prompts, message context, and model execution on the device or local bridge and do not store shared provider credentials. Cloud and custom endpoint providers may receive selected prompts, message context, action metadata, and provider telemetry after explicit cloud processing opt-in. Their API keys and bearer tokens are represented only through secure references resolved by platform secure storage at runtime.
+Current repository behavior: no code connects to Telegram, stores Telegram sessions, receives messages, or sends messages.
 
-Settings synchronization can move safe appearance, notification, and non-activating agent preference fields between devices only after explicit user enablement. Platform adapters must encrypt sync envelopes before storage or transport, and each device must resolve its own local encryption key reference. Sync does not copy provider tokens, proxy secrets, secure storage keys, local device lock settings, or agent memory.
+Planned behavior: Telegram traffic is handled through TDLib behind platform adapters. Telegram API credential references, session references, message caches, contact metadata, media metadata, and update streams stay inside the platform boundary or local app storage unless the user starts a flow that intentionally sends data through Telegram services. Shared foundation code must not log message text, chat titles, phone numbers, Telegram credential values, or session secrets.
+
+### Proxy Connectivity
+
+Current repository behavior: proxy settings models validate MTProto, SOCKS5, and HTTP CONNECT configuration shapes and reject raw proxy secrets. No live proxy connection is created by the repository foundation.
+
+Planned behavior: user-configured proxy routes are optional. Platform bridges resolve `secretRef`, `usernameRef`, and `passwordRef` values through local secure storage before passing them to TDLib-native networking APIs. Shared settings snapshots, diagnostics, proxy tests, and network error logs may include proxy ids, protocol names, reachability status, and coarse latency data, but must not include proxy host credentials, MTProto secrets, usernames, passwords, or raw credential references when exporting diagnostics. The optional public proxy catalog remains disabled by default and requires source freshness plus human review metadata before release.
+
+### Teleton Agent
+
+Current repository behavior: the shared settings default the agent mode to `off`, expose local/cloud/hybrid mode choices, validate provider credential references, and model action approvals, notifications, memory, history, and IPC envelopes without starting a runtime.
+
+Planned behavior: local mode keeps prompts, selected message context, model execution, action metadata, and private memory on the device or local companion bridge. Agent memory and action history must follow retention limits and avoid storing raw credentials or private keys. Users can set autonomous action limits, require approvals for sensitive tools, inspect action history, and disable automation without losing access to standard messaging features.
+
+### Cloud Processing
+
+Current repository behavior: cloud-capable modes cannot activate without explicit privacy impact confirmation in the shared settings view state.
+
+Planned behavior: cloud and hybrid modes require explicit cloud processing opt-in before any selected prompt, message context, action metadata, provider telemetry, or tool result is sent to an approved cloud provider or custom HTTPS endpoint. Provider API keys and bearer tokens are represented only through secure references resolved by platform secure storage at runtime. Users can turn off cloud-capable modes, clear provider references, or replace provider references without exposing credential values through shared settings snapshots.
+
+### Settings Synchronization
+
+Current repository behavior: settings synchronization is modeled as disabled by default, accepts only safe shared fields, and excludes secure references plus private agent memory.
+
+Planned behavior: cross-device settings synchronization can move appearance, notification, layout, proxy preference, and non-activating agent preference fields only after explicit user enablement. Platform adapters must encrypt sync envelopes before storage or transport, and each device must resolve its own local encryption key reference. Enabling sync on one device does not enable cloud-capable agent modes or copy sync credentials to another device.
+
+### TON Blockchain
+
+Current repository behavior: TON adapters prepare and validate mock wallet, transfer, swap, NFT, staking, DNS, confirmation, and testnet workflows without accepting plaintext private keys.
+
+Planned behavior: TON operations use wallet-provider integrations, TON SDKs, or secure storage references for signing material. Balance lookup, receive address display, NFT metadata lookup, swap quotes, staking previews, DNS lookups, and transaction status checks may query TON providers or indexers with public wallet addresses and public transaction identifiers. Transfers, swaps, staking, and other wallet-changing operations must require confirmation before signing or broadcasting, and shared code must never log private keys, seed phrases, mnemonics, wallet provider credentials, or protected CI wallet material.
 
 ## User Controls
 
@@ -31,6 +62,14 @@ The planned agent modes are `off`, `local`, `cloud`, and `hybrid`. The default i
 Cloud-capable provider use requires explicit cloud processing opt-in before activation. Users can clear or replace provider references without exposing the underlying credential value through shared settings snapshots.
 
 Users can leave cross-device settings synchronization disabled. Enabling sync on one device does not enable cloud-capable agent modes or copy sync credentials to another device; each device must opt in and provide local secure storage access independently.
+
+TON transaction workflows must preserve a review screen, show the wallet action being prepared, and require explicit confirmation before signing or broadcasting.
+
+## Policy Maintenance
+
+Any pull request that adds, removes, or changes a Telegram, proxy, agent, cloud, settings synchronization, telemetry, diagnostic, storage, or TON data flow must update `PRIVACY.md` in the same pull request. The update must describe the default behavior, user opt-in or opt-out controls, credential handling, logging boundaries, and any external service that can receive user data.
+
+Before release, reviewers must compare this policy against implemented behavior, platform documentation, settings defaults, secure storage boundaries, diagnostics, and tests. Privacy-sensitive changes require human maintainer review through CODEOWNERS before merge and before release readiness is claimed.
 
 ## Security Reporting
 

--- a/test/privacy-policy.test.mjs
+++ b/test/privacy-policy.test.mjs
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+
+const root = new URL('../', import.meta.url);
+
+function pathFor(relativePath) {
+  return new URL(relativePath, root);
+}
+
+function assertIncludesAll(content, patterns, label) {
+  for (const pattern of patterns) {
+    assert.match(content, pattern, `${label} must include ${pattern}`);
+  }
+}
+
+test('privacy policy publishes local processing and data-flow coverage', async () => {
+  const privacy = await readFile(pathFor('PRIVACY.md'), 'utf8');
+
+  assert.match(privacy, /^# Privacy Policy$/m);
+  assert.doesNotMatch(privacy, /Privacy Policy Draft/i);
+
+  assertIncludesAll(
+    privacy,
+    [
+      /^## Current Repository State$/m,
+      /^## Data Handling Principles$/m,
+      /^## Data Flow Coverage$/m,
+      /^### Telegram Messaging$/m,
+      /^### Proxy Connectivity$/m,
+      /^### Teleton Agent$/m,
+      /^### Cloud Processing$/m,
+      /^### Settings Synchronization$/m,
+      /^### TON Blockchain$/m,
+      /^## User Controls$/m,
+      /^## Policy Maintenance$/m
+    ],
+    'PRIVACY.md'
+  );
+
+  assertIncludesAll(
+    privacy,
+    [
+      /does not yet ship a production client/i,
+      /local by default/i,
+      /explicit cloud processing opt-in/i,
+      /default is `off`/i,
+      /require confirmation before signing or broadcasting/i,
+      /update `PRIVACY\.md` in the same pull request/i,
+      /human maintainer review/i
+    ],
+    'privacy policy acceptance criteria'
+  );
+});


### PR DESCRIPTION
## Summary

- Publishes `PRIVACY.md` with explicit current and planned data-flow coverage for Telegram, proxy connectivity, Teleton Agent, cloud processing, settings synchronization, and TON.
- Documents local-by-default behavior, explicit cloud opt-in, agent controls, transaction approval boundaries, and same-PR policy maintenance requirements.
- Adds a regression test that keeps the issue #25 privacy-policy acceptance criteria covered.

## Issue

Fixes #25

## Tests

- [x] `node --test test/privacy-policy.test.mjs`
- [x] `npm test`
- [x] `npm run validate:secrets`
- [x] `npm run validate:foundation`
- [x] `npm run validate:release`
- [x] `npm run decompose:dry-run`

## Risk

- Documentation-only runtime risk. Privacy-sensitive documentation still requires human maintainer review before release.

## Screenshots or recordings

Not applicable.

## Security and privacy

- [x] This PR does not include secrets, production credentials, access tokens, Telegram API hashes, private keys, or private message content.
- [x] Any logs, screenshots, or fixtures are redacted.
- [x] Security-sensitive changes request human maintainer review before release.