### PR TITLE
[055] Create security audit system

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -3,6 +3,7 @@ set -eu
 
 npm test
 npm run validate:secrets
+npm run audit:security
 npm run validate:foundation
 npm run validate:release
 npm run decompose:dry-run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Scan committed files for secrets
         run: npm run validate:secrets
 
+      - name: Generate security audit evidence
+        run: npm run audit:security
+
       - name: Validate foundation artifacts
         run: npm run validate:foundation
 

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -26,6 +26,15 @@ jobs:
       - name: Validate release metadata
         run: npm run validate:release
 
+      - name: Generate security audit report
+        run: npm run audit:security -- --output security-audit-report.md
+
+      - name: Upload security audit report
+        uses: actions/upload-artifact@v4
+        with:
+          name: security-audit-report
+          path: security-audit-report.md
+
       - name: Preview generated changelog
         run: npm run changelog
         env:

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -30,6 +30,7 @@ jobs:
         run: npm run audit:security -- --output security-audit-report.md
 
       - name: Upload security audit report
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: security-audit-report

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-26T20:52:22.987Z for PR creation at branch issue-66-89abfd2cf372 for issue https://github.com/xlabtg/Teleton-Client/issues/66

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-26T20:52:22.987Z for PR creation at branch issue-66-89abfd2cf372 for issue https://github.com/xlabtg/Teleton-Client/issues/66

--- a/BUILD-GUIDE.md
+++ b/BUILD-GUIDE.md
@@ -84,6 +84,7 @@ Run the same checks used by CI:
 ```sh
 npm test
 npm run validate:secrets
+npm run audit:security
 npm run validate:foundation
 npm run validate:release
 npm run decompose:dry-run
@@ -132,6 +133,8 @@ Do not hardcode Telegram API credentials, proxy secrets, TON wallet secrets, clo
 Run `npm run validate:secrets` to scan git-tracked files for high-confidence secret patterns before committing or opening a pull request. The command redacts suspected values in output and allows only narrow synthetic fixtures used by redaction tests.
 
 Use `docs/security-audit.md` as the credential inventory and rotation source of truth. It records Telegram, proxy, LLM provider, TON, agent memory, settings sync, and CI credential handling; platform secure storage review requirements; and the human security review required before release.
+
+Run `npm run audit:security -- --output security-audit-report.md` during release preparation. The generated `security-audit-report.md` records automated evidence for secrets, dependency risk, permission boundaries, and release readiness, then lists manual sign-off checkboxes that can be attached to the release review.
 
 ## TON Testnet Checks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Start with:
 ```sh
 npm test
 npm run validate:secrets
+npm run audit:security
 npm run validate:foundation
 npm run validate:release
 npm run decompose:dry-run
@@ -52,6 +53,7 @@ Run the same checks used by CI before opening a pull request and again before as
 ```sh
 npm test
 npm run validate:secrets
+npm run audit:security
 npm run validate:foundation
 npm run validate:release
 npm run decompose:dry-run
@@ -68,6 +70,8 @@ Represent sensitive runtime values through environment variables or secure stora
 Public issues, pull requests, screenshots, fixtures, and logs must be redacted before sharing. Report vulnerabilities through GitHub private security advisories instead of public issues.
 
 Run `npm run validate:secrets` before publishing a branch. The scan rejects high-confidence secret patterns in committed files and redacts findings in command output. Credential inventory, rotation, secure storage review requirements, and release review steps are documented in `docs/security-audit.md`.
+
+Run `npm run audit:security -- --output security-audit-report.md` during release preparation to generate attachable Markdown evidence for secrets, dependency risk, permission boundaries, release readiness, and required manual sign-offs.
 
 Security, privacy, CI, release automation, package metadata, shared client code, and CODEOWNERS changes require human maintainer review according to `.github/CODEOWNERS`.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ This repository is in the foundation phase. The current implementation establish
 - Local Teleton Agent memory encryption contract using platform secure storage key providers, AES-256-GCM payloads, migration, missing-key, locked-store, and key-rotation tests.
 - CI workflow for foundation checks.
 - Automated committed-secret scanning with documented credential rotation and secure storage review requirements.
+- Attachable security audit report for release review evidence across secrets, dependency risk, permission boundaries, and release readiness.
 - Upstream license matrix for TDLib, Telegram reference clients, Teleton Agent, and TON SDK release review.
 - Documented semantic version source of truth and release metadata validation.
 - Required project documents: `README.md`, `PRIVACY.md`, `LICENSE`, and `BUILD-GUIDE.md`.
@@ -51,6 +52,7 @@ This repository is in the foundation phase. The current implementation establish
 ```sh
 npm test
 npm run validate:secrets
+npm run audit:security
 npm run validate:foundation
 npm run validate:release
 npm run decompose:dry-run

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -14,6 +14,25 @@ The scan reads git-tracked text files and rejects high-confidence committed secr
 
 The only allowlisted matches are synthetic fixtures in redaction tests. New allowlist entries require a narrow file path, pattern id, line marker, and human maintainer review.
 
+## Release Audit Report
+
+Generate attachable release-review evidence with:
+
+```sh
+npm run audit:security -- --output security-audit-report.md
+```
+
+The generated Markdown report records the release gate status, automated security checks, redacted secret findings if any are found, and manual release sign-off checkboxes. CI runs the same command, and the release validation workflow uploads `security-audit-report.md` as a review artifact.
+
+| Audit category | Automated evidence | Required human evidence |
+| --- | --- | --- |
+| Secrets | `npm run validate:secrets` scans git-tracked text files and fails on common secret patterns. | Security reviewer confirms credential rotation, secure storage, logs, screenshots, fixtures, pull request text, and release notes are redacted. |
+| Dependency risk | `package.json` dependency metadata and lockfile coverage are checked, and `docs/license-matrix.md` must track upstream license and source publication obligations. | Legal or release reviewer confirms selected dependencies match the license matrix and approves TDLib, Telegram reference, Teleton Agent, TON SDK, copyleft, notice, and app-store obligations. |
+| Permission boundaries | CODEOWNERS coverage, workflow `contents: read` permissions, secure storage review language, and non-publishing release validation are checked. | Security reviewer confirms platform bridges resolve secrets locally, redact diagnostics, and keep elevated permissions out of unreviewed pull request workflows. |
+| Release readiness | `npm run validate:release`, package private state, the audit command, and release workflow artifact generation are checked. | Release manager attaches the report, records validation results, confirms changelog redaction, and keeps publication disabled until public release approval. |
+
+Manual review items must be completed before public release even when automated checks pass.
+
 ## Credential Inventory
 
 | Credential source | Current owner boundary | Required storage | Rotation trigger |

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -22,7 +22,7 @@ Generate attachable release-review evidence with:
 npm run audit:security -- --output security-audit-report.md
 ```
 
-The generated Markdown report records the release gate status, automated security checks, redacted secret findings if any are found, and manual release sign-off checkboxes. CI runs the same command, and the release validation workflow uploads `security-audit-report.md` as a review artifact.
+The generated Markdown report records the release gate status, automated security checks, redacted secret findings if any are found, and manual release sign-off checkboxes. CI runs the same command, and the release validation workflow uploads `security-audit-report.md` as a review artifact even when audit checks fail.
 
 | Audit category | Automated evidence | Required human evidence |
 | --- | --- | --- |

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "node --test test/*.test.mjs",
     "prepare:hooks": "git config core.hooksPath .githooks",
+    "audit:security": "node scripts/audit-security.mjs",
     "validate:secrets": "node scripts/validate-secrets.mjs",
     "validate:foundation": "node scripts/validate-foundation.mjs",
     "validate:release": "node scripts/validate-release.mjs",

--- a/scripts/audit-security.mjs
+++ b/scripts/audit-security.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { createSecurityAudit, formatSecurityAuditReport } from '../src/foundation/security-audit.mjs';
+
+function parseArgs(argv) {
+  const options = {
+    output: null,
+    help: false
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--help' || arg === '-h') {
+      options.help = true;
+      continue;
+    }
+
+    if (arg === '--output') {
+      const output = argv[index + 1];
+      if (!output) {
+        throw new Error('--output requires a file path');
+      }
+      options.output = output;
+      index += 1;
+      continue;
+    }
+
+    if (arg.startsWith('--output=')) {
+      options.output = arg.slice('--output='.length);
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function printHelp() {
+  console.log(`Usage: npm run audit:security -- [--output security-audit-report.md]
+
+Generates a Markdown security audit report for release review. The command exits
+with a non-zero status when automated security audit blockers are present.`);
+}
+
+const options = parseArgs(process.argv.slice(2));
+
+if (options.help) {
+  printHelp();
+  process.exit(0);
+}
+
+const audit = await createSecurityAudit();
+const report = formatSecurityAuditReport(audit);
+
+console.log(report);
+
+if (options.output) {
+  const outputPath = path.resolve(options.output);
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, report, 'utf8');
+  console.error(`Security audit report written to ${outputPath}`);
+}
+
+if (audit.automatedBlockers.length > 0) {
+  console.error(`Security audit blocked by ${audit.automatedBlockers.length} automated check(s).`);
+  process.exitCode = 1;
+}

--- a/scripts/validate-foundation.mjs
+++ b/scripts/validate-foundation.mjs
@@ -27,10 +27,13 @@ const requiredFiles = [
   'docs/license-matrix.md',
   'docs/backlog.md',
   'docs/tdlib-adapter.md',
+  'src/foundation/security-audit.mjs',
   'src/foundation/secret-audit.mjs',
   'src/foundation/agent-runtime-supervisor.mjs',
   'test/agent-runtime-supervisor.test.mjs',
+  'scripts/audit-security.mjs',
   'scripts/validate-secrets.mjs',
+  'test/security-audit-report.test.mjs',
   'test/secret-audit.test.mjs',
   'src/foundation/agent-action-history.mjs',
   'test/agent-action-history.test.mjs',
@@ -126,6 +129,7 @@ const contributing = await readFile(new URL('CONTRIBUTING.md', root), 'utf8');
 const requiredContributingPatterns = [
   /npm test/,
   /npm run validate:secrets/,
+  /npm run audit:security/,
   /npm run validate:foundation/,
   /npm run validate:release/,
   /npm run decompose:dry-run/,
@@ -145,6 +149,12 @@ for (const pattern of requiredContributingPatterns) {
 
 const packageJson = JSON.parse(await readFile(new URL('package.json', root), 'utf8'));
 assert.equal(
+  packageJson.scripts['audit:security'],
+  'node scripts/audit-security.mjs',
+  'package.json must expose the security audit report command'
+);
+
+assert.equal(
   packageJson.scripts['validate:secrets'],
   'node scripts/validate-secrets.mjs',
   'package.json must expose the secret validation command'
@@ -152,13 +162,32 @@ assert.equal(
 
 const preCommitHook = await readFile(new URL('.githooks/pre-commit', root), 'utf8');
 assert.match(preCommitHook, /npm run validate:secrets/, 'pre-commit hook must run the secret scan');
+assert.match(preCommitHook, /npm run audit:security/, 'pre-commit hook must generate security audit evidence');
 
 const ciWorkflow = await readFile(new URL('.github/workflows/ci.yml', root), 'utf8');
 assert.match(ciWorkflow, /npm run validate:secrets/, 'CI must run the secret scan');
+assert.match(ciWorkflow, /npm run audit:security/, 'CI must generate security audit evidence');
+
+const releaseWorkflow = await readFile(new URL('.github/workflows/release-validation.yml', root), 'utf8');
+assert.match(
+  releaseWorkflow,
+  /npm run audit:security -- --output security-audit-report\.md/,
+  'release validation must generate an attachable security audit report'
+);
+assert.match(
+  releaseWorkflow,
+  /actions\/upload-artifact@v4/,
+  'release validation must upload the security audit report artifact'
+);
 
 const securityAudit = await readFile(new URL('docs/security-audit.md', root), 'utf8');
 const requiredSecurityAuditPatterns = [
   /npm run validate:secrets/,
+  /npm run audit:security -- --output security-audit-report\.md/,
+  /security-audit-report\.md/,
+  /Dependency risk/i,
+  /Permission boundaries/i,
+  /Release readiness/i,
   /Credential Inventory/i,
   /Credential Rotation/i,
   /Secure Storage Review/i,

--- a/scripts/validate-foundation.mjs
+++ b/scripts/validate-foundation.mjs
@@ -179,6 +179,11 @@ assert.match(
   /actions\/upload-artifact@v4/,
   'release validation must upload the security audit report artifact'
 );
+assert.match(
+  releaseWorkflow,
+  /if:\s*always\(\)/,
+  'release validation must preserve the security audit artifact when audit checks fail'
+);
 
 const securityAudit = await readFile(new URL('docs/security-audit.md', root), 'utf8');
 const requiredSecurityAuditPatterns = [

--- a/src/foundation/security-audit.mjs
+++ b/src/foundation/security-audit.mjs
@@ -315,10 +315,12 @@ export async function createSecurityAudit({
             /npm run validate:release/.test(releaseWorkflow) &&
             /npm run audit:security -- --output security-audit-report\.md/.test(releaseWorkflow) &&
             /actions\/upload-artifact@v4/.test(releaseWorkflow) &&
+            /if:\s*always\(\)/.test(releaseWorkflow) &&
             !/npm\s+publish/.test(releaseWorkflow)
               ? 'pass'
               : 'blocked',
-          evidence: '.github/workflows/release-validation.yml validates metadata, generates a security audit report artifact, and does not publish.'
+          evidence:
+            '.github/workflows/release-validation.yml validates metadata, preserves the security audit report artifact, and does not publish.'
         })
       ]
     })

--- a/src/foundation/security-audit.mjs
+++ b/src/foundation/security-audit.mjs
@@ -1,0 +1,407 @@
+import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+import { formatSecretAuditFindings, scanRepositoryForSecrets } from './secret-audit.mjs';
+
+const defaultRoot = new URL('../../', import.meta.url);
+
+const PACKAGE_DEPENDENCY_FIELDS = Object.freeze([
+  'dependencies',
+  'devDependencies',
+  'optionalDependencies',
+  'peerDependencies'
+]);
+
+export const SECURITY_AUDIT_CATEGORY_IDS = Object.freeze([
+  'secrets',
+  'dependency-risk',
+  'permission-boundaries',
+  'release-readiness'
+]);
+
+export const SECURITY_AUDIT_MANUAL_REVIEW_ITEMS = Object.freeze([
+  {
+    id: 'human-security-reviewer',
+    title: 'Human security reviewer',
+    owner: 'security maintainer',
+    evidence:
+      'Record the latest npm test, npm run validate:secrets, npm run audit:security, npm run validate:foundation, and npm run validate:release results.'
+  },
+  {
+    id: 'human-legal-reviewer',
+    title: 'Human legal reviewer',
+    owner: 'legal or release maintainer',
+    evidence:
+      'Confirm shipped dependencies match docs/license-matrix.md and that copyleft, notice, source publication, and app-store obligations are approved.'
+  },
+  {
+    id: 'release-manager',
+    title: 'Release manager',
+    owner: 'release maintainer',
+    evidence:
+      'Attach this report to release review, confirm release notes and screenshots are redacted, and keep package publication disabled until public release approval.'
+  }
+]);
+
+function normalizeRoot(root) {
+  if (root instanceof URL) {
+    return root;
+  }
+
+  return pathToFileURL(`${path.resolve(String(root))}${path.sep}`);
+}
+
+function rootToPath(root) {
+  return fileURLToPath(normalizeRoot(root));
+}
+
+async function readText(root, relativePath) {
+  try {
+    return await readFile(new URL(relativePath, root), 'utf8');
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return '';
+    }
+    throw error;
+  }
+}
+
+function parseJson(content, fallback = {}) {
+  if (!content.trim()) {
+    return fallback;
+  }
+
+  return JSON.parse(content);
+}
+
+function hasPatterns(content, patterns) {
+  return patterns.every((pattern) => pattern.test(content));
+}
+
+function hasCodeownerPattern(codeowners, pattern) {
+  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(`^${escaped}\\s+@`, 'm').test(codeowners);
+}
+
+function hasReadOnlyContentsPermission(workflow) {
+  return /permissions:\s*\n\s*contents:\s*read/i.test(workflow) && !/contents:\s*write/i.test(workflow);
+}
+
+function collectPackageDependencies(packageJson) {
+  const groups = PACKAGE_DEPENDENCY_FIELDS.map((field) => ({
+    field,
+    entries: Object.entries(packageJson[field] ?? {})
+  })).filter((group) => group.entries.length > 0);
+
+  return {
+    groups,
+    totalCount: groups.reduce((total, group) => total + group.entries.length, 0)
+  };
+}
+
+function hasPackageLock(rootPath) {
+  return ['package-lock.json', 'npm-shrinkwrap.json', 'pnpm-lock.yaml', 'yarn.lock'].some((file) =>
+    existsSync(path.join(rootPath, file))
+  );
+}
+
+function dependencyEvidence(metadata, lockfilePresent) {
+  if (metadata.totalCount === 0) {
+    return 'package.json declares no package dependencies; dependency risk is limited to planned upstreams in docs/license-matrix.md.';
+  }
+
+  const groups = metadata.groups.map((group) => `${group.field}: ${group.entries.length}`).join(', ');
+  const lockfile = lockfilePresent ? 'a package lockfile is present' : 'no package lockfile is present';
+  return `package.json declares ${metadata.totalCount} package dependenc(ies) (${groups}); ${lockfile}.`;
+}
+
+function createCheck({ id, title, status, evidence, command }) {
+  return Object.freeze({
+    id,
+    title,
+    status,
+    evidence,
+    command
+  });
+}
+
+function createCategory({ id, title, requiredEvidence, checks }) {
+  const status = checks.some((check) => check.status === 'blocked') ? 'blocked' : 'pass';
+
+  return Object.freeze({
+    id,
+    title,
+    status,
+    requiredEvidence,
+    checks
+  });
+}
+
+function collectBlockingChecks(categories) {
+  return categories.flatMap((category) =>
+    category.checks
+      .filter((check) => check.status === 'blocked')
+      .map((check) => ({
+        categoryId: category.id,
+        categoryTitle: category.title,
+        checkId: check.id,
+        checkTitle: check.title,
+        evidence: check.evidence
+      }))
+  );
+}
+
+function oneLine(value) {
+  return String(value).replace(/\s+/g, ' ').trim();
+}
+
+function escapeTableCell(value) {
+  return oneLine(value).replaceAll('|', '\\|');
+}
+
+function statusLabel(status) {
+  return status.toUpperCase().replaceAll('-', ' ');
+}
+
+export async function createSecurityAudit({
+  root = defaultRoot,
+  generatedAt = new Date().toISOString(),
+  secretScanResult
+} = {}) {
+  const auditRoot = normalizeRoot(root);
+  const rootPath = rootToPath(auditRoot);
+
+  const [packageText, securityAuditDoc, licenseMatrixDoc, codeowners, ciWorkflow, releaseWorkflow] =
+    await Promise.all([
+      readText(auditRoot, 'package.json'),
+      readText(auditRoot, 'docs/security-audit.md'),
+      readText(auditRoot, 'docs/license-matrix.md'),
+      readText(auditRoot, '.github/CODEOWNERS'),
+      readText(auditRoot, '.github/workflows/ci.yml'),
+      readText(auditRoot, '.github/workflows/release-validation.yml')
+    ]);
+
+  const packageJson = parseJson(packageText);
+  const dependencies = collectPackageDependencies(packageJson);
+  const lockfilePresent = hasPackageLock(rootPath);
+  const secrets = secretScanResult ?? (await scanRepositoryForSecrets({ root: auditRoot }));
+
+  const categories = [
+    createCategory({
+      id: 'secrets',
+      title: 'Secrets',
+      requiredEvidence: [
+        'Automated scan of git-tracked text files with redacted findings only.',
+        'Credential inventory, rotation, and secure storage rules documented for release reviewers.'
+      ],
+      checks: [
+        createCheck({
+          id: 'committed-secret-scan',
+          title: 'Committed secret scan',
+          status: secrets.findings.length === 0 ? 'pass' : 'blocked',
+          evidence:
+            secrets.findings.length === 0
+              ? `npm run validate:secrets scanned ${secrets.scannedFileCount} tracked file(s) with 0 findings.`
+              : `npm run validate:secrets found ${secrets.findings.length} unapproved secret-like value(s).`,
+          command: 'npm run validate:secrets'
+        }),
+        createCheck({
+          id: 'credential-inventory',
+          title: 'Credential inventory and rotation rules',
+          status: hasPatterns(securityAuditDoc, [
+            /Credential Inventory/i,
+            /Credential Rotation/i,
+            /Secure Storage Review/i,
+            /Human Security Review/i
+          ])
+            ? 'pass'
+            : 'blocked',
+          evidence: 'docs/security-audit.md records credential classes, rotation triggers, secure storage, and review gates.'
+        })
+      ]
+    }),
+    createCategory({
+      id: 'dependency-risk',
+      title: 'Dependency Risk',
+      requiredEvidence: [
+        'Package dependency metadata is reviewed and lockfile coverage is present when dependencies are introduced.',
+        'Planned upstreams and license obligations are tracked before release readiness.'
+      ],
+      checks: [
+        createCheck({
+          id: 'package-dependency-metadata',
+          title: 'Package dependency metadata',
+          status: dependencies.totalCount === 0 || lockfilePresent ? 'pass' : 'blocked',
+          evidence: dependencyEvidence(dependencies, lockfilePresent)
+        }),
+        createCheck({
+          id: 'license-matrix',
+          title: 'Upstream license and dependency risk matrix',
+          status: hasPatterns(licenseMatrixDoc, [
+            /Human legal review/i,
+            /release readiness/i,
+            /source publication/i,
+            /Release Sign-Off Checklist/i
+          ])
+            ? 'pass'
+            : 'blocked',
+          evidence: 'docs/license-matrix.md tracks upstream licenses, copyleft boundaries, source obligations, and release sign-off.'
+        })
+      ]
+    }),
+    createCategory({
+      id: 'permission-boundaries',
+      title: 'Permission Boundaries',
+      requiredEvidence: [
+        'Security-sensitive repository paths require human maintainer ownership review.',
+        'CI and release workflows use read-only repository permissions unless a reviewed release job requires more.'
+      ],
+      checks: [
+        createCheck({
+          id: 'codeowners-security-coverage',
+          title: 'CODEOWNERS coverage for high-risk paths',
+          status:
+            ['*', '.github/workflows/', '.github/CODEOWNERS', 'src/', 'scripts/', 'docs/', 'package.json'].every(
+              (pattern) => hasCodeownerPattern(codeowners, pattern)
+            ) && /human maintainer/i.test(codeowners)
+              ? 'pass'
+              : 'blocked',
+          evidence: '.github/CODEOWNERS covers workflows, shared source, scripts, docs, package metadata, and ownership changes.'
+        }),
+        createCheck({
+          id: 'workflow-permissions',
+          title: 'Workflow permission boundaries',
+          status: hasReadOnlyContentsPermission(ciWorkflow) && hasReadOnlyContentsPermission(releaseWorkflow) ? 'pass' : 'blocked',
+          evidence: 'CI and release validation workflows declare contents: read permissions and do not publish packages.'
+        }),
+        createCheck({
+          id: 'secure-storage-boundaries',
+          title: 'Secure storage and platform permission boundaries',
+          status: hasPatterns(securityAuditDoc, [/Secure Storage Review/i, /Release enablement is blocked/i])
+            ? 'pass'
+            : 'blocked',
+          evidence: 'docs/security-audit.md blocks release enablement until platform secure storage and diagnostics redaction are reviewed.'
+        })
+      ]
+    }),
+    createCategory({
+      id: 'release-readiness',
+      title: 'Release Readiness',
+      requiredEvidence: [
+        'Release metadata and changelog checks pass before a release review.',
+        'Security audit output is generated as Markdown and uploaded or attached to the release review.'
+      ],
+      checks: [
+        createCheck({
+          id: 'release-package-state',
+          title: 'Package release state',
+          status: packageJson.private === true && packageJson.scripts?.['validate:release'] ? 'pass' : 'blocked',
+          evidence: 'package.json remains private and exposes npm run validate:release for metadata validation.',
+          command: 'npm run validate:release'
+        }),
+        createCheck({
+          id: 'security-audit-command',
+          title: 'Attachable security audit command',
+          status: packageJson.scripts?.['audit:security'] === 'node scripts/audit-security.mjs' ? 'pass' : 'blocked',
+          evidence: 'package.json exposes npm run audit:security to print or write the release audit report.',
+          command: 'npm run audit:security -- --output security-audit-report.md'
+        }),
+        createCheck({
+          id: 'release-workflow',
+          title: 'Release validation workflow',
+          status:
+            /npm run validate:release/.test(releaseWorkflow) &&
+            /npm run audit:security -- --output security-audit-report\.md/.test(releaseWorkflow) &&
+            /actions\/upload-artifact@v4/.test(releaseWorkflow) &&
+            !/npm\s+publish/.test(releaseWorkflow)
+              ? 'pass'
+              : 'blocked',
+          evidence: '.github/workflows/release-validation.yml validates metadata, generates a security audit report artifact, and does not publish.'
+        })
+      ]
+    })
+  ];
+
+  const automatedBlockers = collectBlockingChecks(categories);
+
+  return Object.freeze({
+    generatedAt,
+    status: automatedBlockers.length > 0 ? 'blocked' : 'ready-for-human-review',
+    package: Object.freeze({
+      name: packageJson.name ?? 'unknown-package',
+      version: packageJson.version ?? '0.0.0',
+      private: packageJson.private === true
+    }),
+    categories,
+    automatedBlockers,
+    manualReviewItems: SECURITY_AUDIT_MANUAL_REVIEW_ITEMS,
+    secretFindings: secrets.findings,
+    scannedFileCount: secrets.scannedFileCount
+  });
+}
+
+export function formatSecurityAuditReport(audit) {
+  const lines = [
+    '# Security Audit Release Report',
+    '',
+    `Generated: ${audit.generatedAt}`,
+    `Package: \`${audit.package.name}@${audit.package.version}\``,
+    `Release gate status: \`${audit.status}\``,
+    '',
+    '## Category Summary',
+    '',
+    '| Category | Status | Required evidence |',
+    '| --- | --- | --- |',
+    ...audit.categories.map(
+      (category) =>
+        `| ${escapeTableCell(category.title)} | ${statusLabel(category.status)} | ${escapeTableCell(
+          category.requiredEvidence.join(' ')
+        )} |`
+    ),
+    '',
+    '## Automated Checks',
+    ''
+  ];
+
+  for (const category of audit.categories) {
+    lines.push(`### ${category.title}`, '');
+
+    for (const check of category.checks) {
+      lines.push(`- **${statusLabel(check.status)}** ${check.title}: ${check.evidence}`);
+      if (check.command) {
+        lines.push(`  Command: \`${check.command}\``);
+      }
+    }
+
+    lines.push('');
+  }
+
+  if (audit.secretFindings.length > 0) {
+    lines.push('## Secret Findings', '', '```text', formatSecretAuditFindings(audit.secretFindings), '```', '');
+  }
+
+  if (audit.automatedBlockers.length > 0) {
+    lines.push('## Automated Blockers', '');
+    for (const blocker of audit.automatedBlockers) {
+      lines.push(`- ${blocker.categoryTitle} / ${blocker.checkTitle}: ${blocker.evidence}`);
+    }
+    lines.push('');
+  }
+
+  lines.push('## Manual Release Sign-Off', '');
+  for (const item of audit.manualReviewItems) {
+    lines.push(`- [ ] **${item.title}** (${item.owner}): ${item.evidence}`);
+  }
+
+  lines.push(
+    '',
+    '## Attach This Output',
+    '',
+    'Run `npm run audit:security -- --output security-audit-report.md` and attach the generated Markdown report to the release review after automated blockers are resolved. Manual sign-off remains required before public release.',
+    ''
+  );
+
+  return lines.join('\n');
+}

--- a/test/foundation.test.mjs
+++ b/test/foundation.test.mjs
@@ -33,7 +33,10 @@ test('foundation artifacts required by issue 1 are present', () => {
     'docs/security-audit.md',
     'docs/license-matrix.md',
     'docs/contributing-templates.md',
-    'docs/tdlib-adapter.md'
+    'docs/tdlib-adapter.md',
+    'src/foundation/security-audit.mjs',
+    'scripts/audit-security.mjs',
+    'test/security-audit-report.test.mjs'
   ];
 
   for (const requiredFile of requiredFiles) {
@@ -103,6 +106,7 @@ test('pre-commit hook is installable and runs deterministic local checks', async
   assert.match(hook, /^#!\/usr\/bin\/env sh\n/, 'pre-commit hook should be directly executable');
   assert.match(hook, /npm test/, 'pre-commit hook should run the test suite');
   assert.match(hook, /npm run validate:secrets/, 'pre-commit hook should run the secret scan');
+  assert.match(hook, /npm run audit:security/, 'pre-commit hook should generate security audit evidence');
   assert.match(hook, /npm run validate:foundation/, 'pre-commit hook should run foundation validation');
   assert.match(hook, /npm run validate:release/, 'pre-commit hook should run release metadata validation');
   assert.match(hook, /npm run decompose:dry-run/, 'pre-commit hook should run the deterministic dry run');
@@ -115,6 +119,10 @@ test('security audit documents scanning, rotation, secure storage, and human rev
   const ci = await readFile(pathFor('.github/workflows/ci.yml'), 'utf8');
 
   assert.match(audit, /npm run validate:secrets/);
+  assert.match(audit, /npm run audit:security -- --output security-audit-report\.md/);
+  assert.match(audit, /Dependency risk/i);
+  assert.match(audit, /Permission boundaries/i);
+  assert.match(audit, /Release readiness/i);
   assert.match(audit, /Credential Inventory/i);
   assert.match(audit, /Credential Rotation/i);
   assert.match(audit, /Secure Storage Review/i);
@@ -129,8 +137,10 @@ test('security audit documents scanning, rotation, secure storage, and human rev
   assert.match(contributing, /docs\/security-audit\.md/);
   assert.match(contributing, /docs\/license-matrix\.md/);
   assert.match(buildGuide, /Credential Inventory/i);
+  assert.match(buildGuide, /security-audit-report\.md/);
   assert.match(buildGuide, /docs\/license-matrix\.md/);
   assert.match(ci, /npm run validate:secrets/);
+  assert.match(ci, /npm run audit:security/);
 });
 
 test('epic backlog decomposes issue 1 into prioritized phases', async () => {

--- a/test/security-audit-report.test.mjs
+++ b/test/security-audit-report.test.mjs
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+
+import { scanTextForSecrets } from '../src/foundation/secret-audit.mjs';
+import { createSecurityAudit, formatSecurityAuditReport } from '../src/foundation/security-audit.mjs';
+
+const root = new URL('../', import.meta.url);
+const generatedAt = '2026-04-26T00:00:00.000Z';
+
+function pathFor(relativePath) {
+  return new URL(relativePath, root);
+}
+
+async function readJson(relativePath) {
+  return JSON.parse(await readFile(pathFor(relativePath), 'utf8'));
+}
+
+test('security audit report assembles release-gate evidence and manual sign-offs', async () => {
+  const audit = await createSecurityAudit({ root, generatedAt });
+  const report = formatSecurityAuditReport(audit);
+
+  assert.equal(audit.status, 'ready-for-human-review');
+  assert.deepEqual(
+    audit.categories.map((category) => category.id),
+    ['secrets', 'dependency-risk', 'permission-boundaries', 'release-readiness']
+  );
+  assert.deepEqual(audit.automatedBlockers, []);
+
+  assert.match(report, /^# Security Audit Release Report/m);
+  assert.match(report, /Package: `teleton-client@0\.1\.0`/);
+  assert.match(report, /Release gate status: `ready-for-human-review`/);
+  assert.match(report, /## Manual Release Sign-Off/);
+  assert.match(report, /- \[ \] \*\*Human security reviewer\*\*/);
+  assert.match(report, /- \[ \] \*\*Human legal reviewer\*\*/);
+  assert.match(report, /npm run audit:security -- --output security-audit-report\.md/);
+});
+
+test('security audit report blocks common secret patterns without exposing the value', async () => {
+  const openAiKey = 'sk-proj-' + 'a'.repeat(32);
+  const findings = scanTextForSecrets(`OPENAI_API_KEY="${openAiKey}"`, {
+    filePath: 'sample.env',
+    allowlist: []
+  });
+
+  const audit = await createSecurityAudit({
+    root,
+    generatedAt,
+    secretScanResult: {
+      findings,
+      scannedFileCount: 1,
+      scannedFiles: ['sample.env']
+    }
+  });
+  const report = formatSecurityAuditReport(audit);
+
+  assert.equal(audit.status, 'blocked');
+  assert.equal(audit.automatedBlockers.length, 1);
+  assert.equal(audit.automatedBlockers[0].categoryId, 'secrets');
+  assert.match(report, /Secret Findings/);
+  assert.match(report, /\[secret-like-value\]/);
+  assert.doesNotMatch(report, new RegExp(openAiKey));
+});
+
+test('security audit command is wired into local, CI, and release validation docs', async () => {
+  const packageJson = await readJson('package.json');
+  const ci = await readFile(pathFor('.github/workflows/ci.yml'), 'utf8');
+  const release = await readFile(pathFor('.github/workflows/release-validation.yml'), 'utf8');
+  const contributing = await readFile(pathFor('CONTRIBUTING.md'), 'utf8');
+  const buildGuide = await readFile(pathFor('BUILD-GUIDE.md'), 'utf8');
+
+  assert.equal(packageJson.scripts['audit:security'], 'node scripts/audit-security.mjs');
+  assert.match(ci, /npm run audit:security/);
+  assert.match(release, /npm run audit:security -- --output security-audit-report\.md/);
+  assert.match(release, /actions\/upload-artifact@v4/);
+  assert.match(contributing, /npm run audit:security/);
+  assert.match(buildGuide, /security-audit-report\.md/);
+});

--- a/test/security-audit-report.test.mjs
+++ b/test/security-audit-report.test.mjs
@@ -73,6 +73,7 @@ test('security audit command is wired into local, CI, and release validation doc
   assert.match(ci, /npm run audit:security/);
   assert.match(release, /npm run audit:security -- --output security-audit-report\.md/);
   assert.match(release, /actions\/upload-artifact@v4/);
+  assert.match(release, /if:\s*always\(\)/);
   assert.match(contributing, /npm run audit:security/);
   assert.match(buildGuide, /security-audit-report\.md/);
 });


### PR DESCRIPTION
## Summary

- Add a dependency-free security audit report system that summarizes release-gate evidence for secrets, dependency risk, permission boundaries, and release readiness.
- Add `npm run audit:security` with optional `--output security-audit-report.md`, redacted secret findings, automated blockers, and manual release sign-off checkboxes.
- Wire the audit into pre-commit, CI, release validation artifact upload, foundation validation, README, CONTRIBUTING, BUILD-GUIDE, and `docs/security-audit.md`.

## Issue

Fixes #66

## Reproduction and Verification

- Reproducing check before implementation: `node --test test/security-audit-report.test.mjs` failed with `ERR_MODULE_NOT_FOUND` for `src/foundation/security-audit.mjs`.
- The new test now verifies the attachable report, blocked secret findings with redaction, and workflow/docs wiring.
- Release validation uploads `security-audit-report.md` with `if: always()` so blocked audit reports are preserved for review.

## Tests

- [x] `node --test test/security-audit-report.test.mjs`
- [x] `npm test` (209 passing tests; log saved at `/tmp/teleton-npm-test-final.log` locally)
- [x] `npm run validate:secrets`
- [x] `npm run audit:security`
- [x] `npm run audit:security -- --output /tmp/security-audit-report.md`
- [x] `npm run validate:foundation`
- [x] `npm run validate:release`
- [x] `npm run decompose:dry-run` (log saved at `/tmp/teleton-decompose-dry-run.log` locally)
- [x] Manual checks: `git diff --check`, `git diff --cached --check`, final PR diff review, and confirmed `origin/main` is an ancestor of this branch.

## Risk

- This remains a foundation-phase audit gate. It records release-review evidence and fails automated blockers, but human security/legal/release sign-off is still required before public release.
- Dependency checks currently validate package metadata and release-review documentation because the package remains dependency-free.

## Screenshots or recordings

Not applicable.

## Security and privacy

- [x] This PR does not include secrets, production credentials, access tokens, Telegram API hashes, private keys, or private message content.
- [x] Any logs, screenshots, or fixtures are redacted.
- [x] Security-sensitive changes request human maintainer review before release.
