### PR TITLE
[059] Create SECURITY.md documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,6 +20,7 @@ test/ @xlabtg/teleton-maintainers
 package.json @xlabtg/teleton-maintainers
 
 # Security, privacy, release, and repository automation require human review.
+SECURITY.md @xlabtg/teleton-maintainers
 PRIVACY.md @xlabtg/teleton-maintainers
 LICENSE @xlabtg/teleton-maintainers
 .github/ @xlabtg/teleton-maintainers

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-26T23:42:44.322Z for PR creation at branch issue-70-80a63dbab338 for issue https://github.com/xlabtg/Teleton-Client/issues/70

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-26T23:42:44.322Z for PR creation at branch issue-70-80a63dbab338 for issue https://github.com/xlabtg/Teleton-Client/issues/70

--- a/BUILD-GUIDE.md
+++ b/BUILD-GUIDE.md
@@ -136,6 +136,8 @@ Use `docs/security-audit.md` as the credential inventory and rotation source of 
 
 Run `npm run audit:security -- --output security-audit-report.md` during release preparation. The generated `security-audit-report.md` records automated evidence for secrets, dependency risk, permission boundaries, and release readiness, then lists manual sign-off checkboxes that can be attached to the release review.
 
+Use `SECURITY.md` as the security policy source of truth for supported versions, private vulnerability reporting, coordinated disclosure, and the human maintainer review required before release.
+
 ## TON Testnet Checks
 
 `test/ton-testnet-coverage.test.mjs` runs the TON wallet flow harness in mock mode by default, so local validation never needs wallet secrets or network access. Protected CI can opt into live testnet checks only when all required variables are present:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,8 @@ Run `npm run validate:secrets` before publishing a branch. The scan rejects high
 
 Run `npm run audit:security -- --output security-audit-report.md` during release preparation to generate attachable Markdown evidence for secrets, dependency risk, permission boundaries, release readiness, and required manual sign-offs.
 
+See `SECURITY.md` for supported versions, private vulnerability reporting through GitHub private security advisories, private report expectations, coordinated disclosure timelines, and the human maintainer review required before release.
+
 Security, privacy, CI, release automation, package metadata, shared client code, and CODEOWNERS changes require human maintainer review according to `.github/CODEOWNERS`.
 
 ## Project Documentation
@@ -80,6 +82,7 @@ Security, privacy, CI, release automation, package metadata, shared client code,
 Use these documents as the source of truth for foundation work:
 
 - `README.md` for the current repository status and quick start.
+- `SECURITY.md` for supported versions, private vulnerability reporting, coordinated disclosure, and security policy review.
 - `BUILD-GUIDE.md` for local checks, release metadata, and build expectations.
 - `PRIVACY.md` for data handling principles and security reporting.
 - `docs/security-audit.md` for secret scanning, credential rotation, and secure storage review requirements.

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -91,4 +91,4 @@ Before release, reviewers must compare this policy against implemented behavior,
 
 ## Security Reporting
 
-Please report vulnerabilities through GitHub private security advisories rather than public issues.
+Please report vulnerabilities through GitHub private security advisories rather than public issues. See `SECURITY.md` for supported versions, private report expectations, disclosure timelines, and human maintainer review before release.

--- a/README.md
+++ b/README.md
@@ -45,9 +45,10 @@ This repository is in the foundation phase. The current implementation establish
 - CI workflow for foundation checks.
 - Automated committed-secret scanning with documented credential rotation and secure storage review requirements.
 - Attachable security audit report for release review evidence across secrets, dependency risk, permission boundaries, and release readiness.
+- Published security policy for supported versions, private vulnerability reporting, coordinated disclosure, and human maintainer review before release.
 - Upstream license matrix for TDLib, Telegram reference clients, Teleton Agent, and TON SDK release review.
 - Documented semantic version source of truth and release metadata validation.
-- Required project documents: `README.md`, `PRIVACY.md`, `LICENSE`, and `BUILD-GUIDE.md`.
+- Required project documents: `README.md`, `SECURITY.md`, `PRIVACY.md`, `LICENSE`, and `BUILD-GUIDE.md`.
 
 ## Quick Start
 
@@ -76,7 +77,7 @@ The project is intended to evolve through these layers:
 4. TON blockchain integrations for wallet, transfers, swaps, NFTs, staking, and DNS.
 5. Security and privacy controls for credentials, user consent, and auditability.
 
-See `docs/architecture.md`, `docs/backlog.md`, `docs/tdlib-adapter.md`, `docs/android-wrapper.md`, `docs/ios-wrapper.md`, `docs/desktop-wrapper.md`, `docs/tablet-layout.md`, `docs/web-pwa-wrapper.md`, `docs/security-audit.md`, `docs/license-matrix.md`, and `docs/release-strategy.md` for the current foundation plan. The agent settings, local runtime, input action map, Android wrapper, iOS wrapper, desktop wrapper, tablet layout, PWA, message database encryption, secure data deletion, security audit, and license matrix sections record the shared settings UI contract, supported runtime directions, platform execution boundaries, shortcut and gesture behavior, hardware security key capability checks, responsive tablet behavior, web installability behavior, credential rotation expectations, secure storage review requirements, upstream license obligations, and remaining packaging gaps for Android, iOS, desktop, and web wrappers.
+See `SECURITY.md`, `docs/architecture.md`, `docs/backlog.md`, `docs/tdlib-adapter.md`, `docs/android-wrapper.md`, `docs/ios-wrapper.md`, `docs/desktop-wrapper.md`, `docs/tablet-layout.md`, `docs/web-pwa-wrapper.md`, `docs/security-audit.md`, `docs/license-matrix.md`, and `docs/release-strategy.md` for the current foundation plan. The agent settings, local runtime, input action map, Android wrapper, iOS wrapper, desktop wrapper, tablet layout, PWA, message database encryption, secure data deletion, security policy, security audit, and license matrix sections record the shared settings UI contract, supported runtime directions, platform execution boundaries, shortcut and gesture behavior, hardware security key capability checks, responsive tablet behavior, web installability behavior, vulnerability reporting expectations, credential rotation expectations, secure storage review requirements, upstream license obligations, and remaining packaging gaps for Android, iOS, desktop, and web wrappers.
 
 ## Contribution Templates
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Policy
+
+Teleton Client is in the repository foundation phase. This policy defines how security reports are handled before a production client or public release channel exists.
+
+## Supported Versions
+
+| Version or branch | Support status |
+| --- | --- |
+| `main` branch | Supported for foundation security fixes, policy updates, and release-readiness documentation. |
+| Latest tagged release | No public release exists yet. The first reviewed release must define the supported version window before publication. |
+| Older issue branches, forks, or local builds | Not supported for coordinated fixes. Rebase or upgrade to the current `main` branch before reporting whether a finding is still present. |
+
+Security fixes are prepared against the current supported version line. If a future release creates maintained patch lines, this table must be updated in the same pull request as the release policy change.
+
+## Reporting a Vulnerability
+
+Report vulnerabilities through GitHub private security advisories for this repository. Do not open a public issue, discussion, pull request, or log upload for suspected vulnerabilities.
+
+Include enough detail for maintainers to reproduce and triage safely:
+
+- Affected branch, commit, platform wrapper, or planned integration area.
+- Impact, expected attacker capability, and whether user data, credentials, wallet operations, or agent actions are involved.
+- Minimal reproduction steps, proof-of-concept inputs, and redacted logs or screenshots.
+- Whether the issue may have exposed secrets, private message content, wallet material, or infrastructure credentials.
+
+If a private advisory is unavailable, ask a maintainer for a private intake channel without sharing vulnerability details in public.
+
+## Private Report Expectations
+
+Keep reports private until maintainers coordinate disclosure. Public project areas must not contain production credentials, access tokens, Telegram API IDs or hashes, proxy credentials, LLM provider tokens, TON private keys, seed phrases, private message content, unredacted logs, or exploitable proof-of-concept details.
+
+Use secure references such as `env:NAME`, `keychain:name`, `keystore:name`, or `secret:name` in examples. Replace credential values, user identifiers, chat content, wallet signing material, and endpoint secrets with redacted placeholders before attaching evidence.
+
+Maintainers must keep advisory discussions, reproduction details, patch timing, and reporter contact information within the private advisory or another approved private channel until coordinated disclosure is complete.
+
+## Disclosure Timeline
+
+Maintainers should acknowledge a new private report within three business days and provide an initial triage update within seven calendar days when enough information is available. Severe findings that could expose credentials, private message content, wallet material, or unsafe agent actions should be prioritized ahead of routine foundation work.
+
+Disclosure timing depends on severity, exploitability, release status, and whether users need a fix, mitigation, or credential rotation guidance. Coordinated disclosure should happen only after maintainers have prepared the fix or mitigation, reviewed release notes for redaction, and agreed with the reporter on what can be public.
+
+If a report identifies leaked credentials or private data, maintainers should rotate affected credentials, review recent logs and pull request text, and document the rotation in the private security record before public disclosure.
+
+## Maintainer Review
+
+Human maintainer review is required before release for this security policy, supported version guidance, private vulnerability intake, disclosure notes, and any fix that changes security-sensitive behavior.
+
+Before declaring release readiness, maintainers must confirm that:
+
+- `SECURITY.md`, `PRIVACY.md`, `CONTRIBUTING.md`, and release documentation describe the same reporting and disclosure process.
+- GitHub private security advisories or an approved private intake channel are available.
+- Supported versions are current for the release being prepared.
+- Security fixes, release notes, screenshots, fixtures, pull request text, and CI logs are redacted and do not expose secrets or private message content.

--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -29,6 +29,12 @@ The helper `classifyVersionBump(previousVersion, nextVersion)` records these rul
 - Publishing is intentionally absent from pull request workflows, so unreviewed pull request code cannot publish packages.
 - Future publishing automation should run only from reviewed `main` changes or protected release tags.
 
+## Security Policy Review
+
+Before release readiness is claimed, a human maintainer must review `SECURITY.md` and confirm that supported versions, GitHub private security advisory intake, private report expectations, coordinated disclosure timing, and credential rotation guidance match the release being prepared.
+
+Security fixes and release notes must be checked against the security policy before publication. Advisory identifiers, reproduction details, reporter information, logs, screenshots, and exploit details should stay private until coordinated disclosure is approved.
+
 ## Changelog Workflow
 
 Run `npm run changelog` to print release notes for the current `package.json` version from merged pull requests on `main`. The generated notes group entries by pull request labels and include links to merged pull requests plus issue references found in pull request text such as `Fixes #38`.

--- a/scripts/validate-foundation.mjs
+++ b/scripts/validate-foundation.mjs
@@ -8,6 +8,7 @@ const root = new URL('../', import.meta.url);
 const requiredFiles = [
   'README.md',
   'CONTRIBUTING.md',
+  'SECURITY.md',
   'PRIVACY.md',
   'BUILD-GUIDE.md',
   'LICENSE',
@@ -57,6 +58,7 @@ const requiredOwnershipPatterns = [
   'scripts/',
   'config/',
   'docs/',
+  'SECURITY.md',
   'PRIVACY.md',
   'BUILD-GUIDE.md',
   'package.json'
@@ -135,6 +137,7 @@ const requiredContributingPatterns = [
   /npm run decompose:dry-run/,
   /docs\/contributing-templates\.md/,
   /BUILD-GUIDE\.md/,
+  /SECURITY\.md/,
   /PRIVACY\.md/,
   /docs\/license-matrix\.md/,
   /secrets/i,
@@ -246,6 +249,7 @@ for (const pattern of requiredLicenseMatrixPatterns) {
 const docsToScan = [
   'README.md',
   'CONTRIBUTING.md',
+  'SECURITY.md',
   'PRIVACY.md',
   'BUILD-GUIDE.md',
   'docs/architecture.md',

--- a/test/foundation.test.mjs
+++ b/test/foundation.test.mjs
@@ -16,6 +16,7 @@ async function readJson(relativePath) {
 test('foundation artifacts required by issue 1 are present', () => {
   const requiredFiles = [
     'README.md',
+    'SECURITY.md',
     'PRIVACY.md',
     'BUILD-GUIDE.md',
     'LICENSE',
@@ -58,6 +59,7 @@ test('CODEOWNERS routes high-risk repository areas to human maintainers', async 
     'scripts/',
     'config/',
     'docs/',
+    'SECURITY.md',
     'PRIVACY.md',
     'BUILD-GUIDE.md',
     'package.json'

--- a/test/security-policy.test.mjs
+++ b/test/security-policy.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+
+const root = new URL('../', import.meta.url);
+
+function pathFor(relativePath) {
+  return new URL(relativePath, root);
+}
+
+function assertIncludesAll(content, patterns, label) {
+  for (const pattern of patterns) {
+    assert.match(content, pattern, `${label} must include ${pattern}`);
+  }
+}
+
+test('security policy publishes private vulnerability reporting and disclosure expectations', async () => {
+  const security = await readFile(pathFor('SECURITY.md'), 'utf8');
+  const contributing = await readFile(pathFor('CONTRIBUTING.md'), 'utf8');
+  const releaseStrategy = await readFile(pathFor('docs/release-strategy.md'), 'utf8');
+
+  assert.match(security, /^# Security Policy$/m);
+  assert.doesNotMatch(security, /Security Policy Draft/i);
+
+  assertIncludesAll(
+    security,
+    [
+      /^## Supported Versions$/m,
+      /^## Reporting a Vulnerability$/m,
+      /^## Private Report Expectations$/m,
+      /^## Disclosure Timeline$/m,
+      /^## Maintainer Review$/m
+    ],
+    'SECURITY.md'
+  );
+
+  assertIncludesAll(
+    security,
+    [
+      /GitHub private security advisories/i,
+      /do not open a public issue/i,
+      /supported version/i,
+      /private message content/i,
+      /credential values/i,
+      /acknowledge/i,
+      /coordinated disclosure/i,
+      /human maintainer/i,
+      /before release/i
+    ],
+    'security policy acceptance criteria'
+  );
+
+  assert.match(contributing, /SECURITY\.md/, 'CONTRIBUTING.md must link to the security policy');
+  assert.match(releaseStrategy, /SECURITY\.md/, 'release documentation must link to the security policy');
+  assert.match(releaseStrategy, /security policy/i, 'release documentation must call out policy review');
+});


### PR DESCRIPTION
## Summary

- Add `SECURITY.md` with supported version guidance, private vulnerability reporting, private report expectations, disclosure timeline, and maintainer review gates.
- Link the security policy from contributor, privacy, build, release, README, CODEOWNERS, and foundation validation paths.
- Add automated coverage that reproduces and verifies the issue acceptance criteria.

## Issue

Fixes #70

## Reproduction

Before the fix, `node --test test/security-policy.test.mjs` failed with `ENOENT` because `SECURITY.md` did not exist.

## Tests

- [x] `node --test test/security-policy.test.mjs`
- [x] `npm test`
- [x] `npm run validate:secrets`
- [x] `npm run audit:security`
- [x] `npm run validate:foundation`
- [x] `npm run validate:release`
- [x] `npm run decompose:dry-run`
- [x] Manual checks, if relevant: reviewed staged diff and policy links.

## Risk

- Documentation-only change; release readiness still requires human maintainer review of the security policy before publication.

## Screenshots or recordings

Not applicable.

## Security and privacy

- [x] This PR does not include secrets, production credentials, access tokens, Telegram API hashes, private keys, or private message content.
- [x] Any logs, screenshots, or fixtures are redacted.
- [x] Security-sensitive changes request human maintainer review before release.