### PR TITLE
[060] Add unit tests for ProxyManager, TON adapter, and IPC bridge

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-26T23:54:41.758Z for PR creation at branch issue-26-2a56fefd7cc0 for issue https://github.com/xlabtg/Teleton-Client/issues/26

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-26T23:54:41.758Z for PR creation at branch issue-26-2a56fefd7cc0 for issue https://github.com/xlabtg/Teleton-Client/issues/26

--- a/test/agent-ipc-bridge.test.mjs
+++ b/test/agent-ipc-bridge.test.mjs
@@ -149,6 +149,56 @@ test('agent IPC bridge exposes plugin management request helpers', async () => {
   bridge.close();
 });
 
+test('agent IPC bridge rejects pending requests when the agent returns an error envelope', async () => {
+  const transport = createMockAgentIpcTransport();
+  const bridge = createAgentIpcBridge({ transport });
+
+  const responsePromise = bridge.request('agent.task.create', { text: 'summarize chat' });
+  assert.deepEqual(bridge.pendingRequestIds(), ['ui.request.1']);
+
+  transport.deliver({
+    id: 'agent.error.1',
+    kind: 'error',
+    source: 'agent',
+    target: 'ui',
+    replyTo: 'ui.request.1',
+    error: {
+      code: 'agent.permission_denied',
+      message: 'User confirmation is required.'
+    }
+  });
+
+  await assert.rejects(() => responsePromise, /User confirmation is required/);
+  assert.deepEqual(bridge.pendingRequestIds(), []);
+
+  bridge.close();
+});
+
+test('agent IPC bridge reports malformed inbound messages through the error hook', () => {
+  const errors = [];
+  const transport = createMockAgentIpcTransport();
+  const bridge = createAgentIpcBridge({
+    transport,
+    onError: (error) => errors.push(error.message)
+  });
+
+  assert.throws(
+    () =>
+      transport.deliver({
+        id: 'bad-event',
+        kind: 'event',
+        source: 'agent',
+        target: 'ui',
+        eventType: 'agent.unknown'
+      }),
+    /Unsupported IPC event type/
+  );
+
+  assert.deepEqual(errors, ['Unsupported IPC event type: agent.unknown']);
+
+  bridge.close();
+});
+
 test('agent IPC bridge rejects malformed messages before dispatch', () => {
   assert.throws(() => parseAgentIpcEnvelope('{'), /Malformed IPC message JSON/);
   assert.throws(

--- a/test/proxy-manager.test.mjs
+++ b/test/proxy-manager.test.mjs
@@ -194,6 +194,76 @@ test('proxy manager keeps manual active proxy selection when automatic switching
   }).proxyId, 'mtproto-primary');
 });
 
+test('proxy manager ignores proxy health when proxy preferences are disabled', () => {
+  const manager = createProxyManager({
+    proxy: {
+      ...proxySettings,
+      enabled: false,
+      activeProxyId: null
+    }
+  });
+
+  assert.deepEqual(manager.chooseRoute({
+    direct: { reachable: true },
+    proxies: {
+      'mtproto-primary': { healthy: true, latencyMs: 1 }
+    }
+  }), {
+    type: 'direct',
+    proxyId: null
+  });
+
+  assert.equal(manager.chooseRoute({
+    direct: { reachable: false },
+    proxies: {
+      'mtproto-primary': { healthy: true, latencyMs: 1 }
+    }
+  }), null);
+});
+
+test('proxy preferences validation rejects missing active proxy and duplicate entries', () => {
+  const missingActiveProxy = validateProxyPreferences({
+    enabled: true,
+    autoSwitchEnabled: true,
+    activeProxyId: 'missing-proxy',
+    entries: [
+      {
+        id: 'mtproto-primary',
+        protocol: 'mtproto',
+        host: 'mtproto.example',
+        port: 443,
+        secretRef: 'env:TELETON_MTPROTO_SECRET'
+      }
+    ]
+  });
+
+  assert.equal(missingActiveProxy.valid, false);
+  assert.match(missingActiveProxy.errors.join('\n'), /missing activeProxyId: missing-proxy/);
+
+  const duplicateEntries = validateProxyPreferences({
+    enabled: true,
+    autoSwitchEnabled: true,
+    activeProxyId: 'socks-office',
+    entries: [
+      {
+        id: 'socks-office',
+        protocol: 'socks5',
+        host: '127.0.0.1',
+        port: 1080
+      },
+      {
+        id: 'socks-office',
+        protocol: 'socks5',
+        host: '127.0.0.2',
+        port: 1081
+      }
+    ]
+  });
+
+  assert.equal(duplicateEntries.valid, false);
+  assert.match(duplicateEntries.errors.join('\n'), /duplicate id/);
+});
+
 test('proxy manager persists validated user proxy preferences without raw secrets', () => {
   const manager = createProxyManager();
 

--- a/test/ton-adapter.test.mjs
+++ b/test/ton-adapter.test.mjs
@@ -230,6 +230,83 @@ test('TON adapter validates bridge inputs before provider calls', async () => {
   ]);
 });
 
+test('TON adapter exposes provider failures while blocking invalid status queries before provider calls', async () => {
+  const calls = [];
+  const adapter = createTonWalletAdapter(
+    {
+      async getBalance() {
+        calls.push({ method: 'getBalance' });
+        throw new Error('wallet provider unavailable');
+      },
+      async getReceiveAddress() {
+        calls.push({ method: 'getReceiveAddress' });
+        return { address: 'EQDsenderAddress' };
+      },
+      async prepareTransfer(request) {
+        calls.push({ method: 'prepareTransfer', request });
+        return { id: 'draft-1', ...request, status: 'draft', signed: false, requiresSigningConfirmation: true };
+      },
+      async getTransferStatus(id) {
+        calls.push({ method: 'getTransferStatus', id });
+        return { id, status: 'pending' };
+      }
+    },
+    {
+      address: 'EQDsenderAddress',
+      walletProviderRef: 'wallet:tonkeeper:test-wallet'
+    }
+  );
+
+  await assert.rejects(() => adapter.getBalance(), /wallet provider unavailable/);
+  await assert.rejects(() => adapter.getTransferStatus('   '), /transfer status id/);
+  assert.deepEqual(calls, [{ method: 'getBalance' }]);
+
+  assert.deepEqual(await adapter.getTransferStatus('draft-1'), {
+    id: 'draft-1',
+    status: 'pending'
+  });
+  assert.deepEqual(calls.at(-1), { method: 'getTransferStatus', id: 'draft-1' });
+});
+
+test('TON adapter reports unsupported optional Jetton transfer capability explicitly', async () => {
+  const adapter = createTonWalletAdapter(
+    {
+      async getBalance() {
+        return { balanceNanoTon: 1n };
+      },
+      async getReceiveAddress() {
+        return { address: 'EQDsenderAddress' };
+      },
+      async prepareTransfer(request) {
+        return { id: 'draft-1', ...request, status: 'draft', signed: false, requiresSigningConfirmation: true };
+      },
+      async getTransferStatus(id) {
+        return { id, status: 'draft' };
+      }
+    },
+    {
+      address: 'EQDsenderAddress',
+      walletProviderRef: 'wallet:tonkeeper:test-wallet'
+    }
+  );
+
+  await assert.rejects(
+    () =>
+      adapter.prepareJettonTransfer({
+        jettonMasterAddress: 'EQDjettonMaster',
+        to: 'EQDreceiverAddress',
+        amountAtomic: 100n,
+        confirmed: true
+      }),
+    (error) => {
+      assert.equal(error.name, 'TonWalletAdapterError');
+      assert.equal(error.code, 'unsupported_jetton_transfer');
+      assert.match(error.message, /does not support Jetton transfer/);
+      return true;
+    }
+  );
+});
+
 test('TON transfer validation rejects secret material in transfer requests', () => {
   const validation = validateTonTransferRequest(
     {


### PR DESCRIPTION
## Summary

- Adds ProxyManager tests for disabled preferences, direct fallback, missing active proxy, and duplicate proxy IDs.
- Adds TON adapter tests for provider failure propagation, invalid status query preflight validation, and unsupported Jetton transfer capability errors.
- Adds IPC bridge tests for remote error envelopes and malformed inbound message error hooks.
- Removes the generated placeholder `.gitkeep`.

## Issue

Fixes #26

## Tests

- [x] `node --test test/proxy-manager.test.mjs test/ton-adapter.test.mjs test/agent-ipc-bridge.test.mjs`
- [x] `npm test`
- [x] `npm run validate:secrets`
- [x] `npm run audit:security`
- [x] `npm run validate:foundation`
- [x] `npm run validate:release`
- [x] `npm run decompose:dry-run`

## Risk

- Low. Test-only coverage changes; no runtime code paths changed.

## Screenshots or recordings

Not applicable.

## Security and privacy

- [x] This PR does not include secrets, production credentials, access tokens, Telegram API hashes, private keys, or private message content.
- [x] Any logs, screenshots, or fixtures are redacted.
- [x] Security-sensitive changes request human maintainer review before release.