### PR TITLE
[062] Add release artifact packaging matrix

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,4 +6,5 @@ npm run validate:secrets
 npm run audit:security
 npm run validate:foundation
 npm run validate:release
+npm run build:debug-artifacts
 npm run decompose:dry-run

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -40,3 +40,43 @@ jobs:
         run: npm run changelog
         env:
           GH_TOKEN: ${{ github.token }}
+
+  debug-artifacts:
+    name: Debug artifact contracts (${{ matrix.target_id }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target_id: android-debug-apk
+            artifact_name: android-debug-apk
+            runner: ubuntu-latest
+          - target_id: ios-debug-app-bundle
+            artifact_name: ios-debug-app-bundle
+            runner: macos-latest
+          - target_id: desktop-macos-debug-app-bundle
+            artifact_name: desktop-macos-debug-app-bundle
+            runner: macos-latest
+          - target_id: desktop-windows-debug-exe
+            artifact_name: desktop-windows-debug-exe
+            runner: windows-latest
+          - target_id: desktop-linux-debug-executable
+            artifact_name: desktop-linux-debug-executable
+            runner: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Build unsigned debug artifact manifest
+        run: npm run build:debug-artifacts -- --target ${{ matrix.target_id }} --build-id ${{ github.sha }} --output dist/debug-artifacts
+
+      - name: Upload unsigned debug artifact manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: dist/debug-artifacts/${{ matrix.target_id }}.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 coverage/
+dist/
 ci-logs/
 *.log
 .DS_Store

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-04-27T00:02:26.981Z for PR creation at branch issue-27-e169ead3bf4d for issue https://github.com/xlabtg/Teleton-Client/issues/27

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-04-27T00:02:26.981Z for PR creation at branch issue-27-e169ead3bf4d for issue https://github.com/xlabtg/Teleton-Client/issues/27
+# Updated: 2026-04-27T00:15:27.044Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-# .gitkeep file auto-generated at 2026-04-27T00:02:26.981Z for PR creation at branch issue-27-e169ead3bf4d for issue https://github.com/xlabtg/Teleton-Client/issues/27
-# Updated: 2026-04-27T00:15:27.044Z

--- a/BUILD-GUIDE.md
+++ b/BUILD-GUIDE.md
@@ -55,6 +55,16 @@ desktop/out/debug/linux-x64/teleton-client
 
 The contract declares app id `dev.teleton.client`, product name `Teleton Client`, tray menu actions, system notification mapping, focused-window and opt-in global shortcuts from the shared input action map, launch-at-login configuration for macOS, Windows, and Linux, protocol routing for Telegram and TON flows, and release packaging targets for DMG, EXE, and AppImage. See `docs/desktop-wrapper.md` for the desktop API mapping and packaging plan.
 
+## Release Packaging
+
+The release artifact matrix in `src/foundation/release-artifacts.mjs` covers Android APK, iOS IPA, macOS DMG, Windows EXE, and Linux AppImage release targets. Public CI builds unsigned debug artifact manifests for Android, iOS, macOS, Windows, and Linux with:
+
+```sh
+npm run build:debug-artifacts
+```
+
+The generated manifests are written to `dist/debug-artifacts/` and are uploaded by `.github/workflows/release-validation.yml`. They record the expected debug artifact paths without using signing secrets. Signed packages must be produced only in the protected `release-signing` environment after human release review. See `docs/release-packaging.md` for the artifact matrix, signing boundary, and publication steps.
+
 ## Input Action Map
 
 The shared input action map in `src/platform/action-map.mjs` defines common messaging, Teleton Agent, and TON wallet routes once, then adapts them to desktop shortcuts and mobile gestures. The generated plans include collision reports, reserved mobile system gesture notes, accessibility requirements, and `input.riskyActionBindings.enabled` so risky agent or transaction bindings can be disabled without removing visible workflow controls.
@@ -87,6 +97,7 @@ npm run validate:secrets
 npm run audit:security
 npm run validate:foundation
 npm run validate:release
+npm run build:debug-artifacts
 npm run decompose:dry-run
 ```
 
@@ -105,6 +116,8 @@ The pre-commit hook runs the same foundation checks as CI before allowing a comm
 ## Release Metadata
 
 `package.json` is the only version source of truth for the current package, application, and release metadata. Run `npm run validate:release` before changing release metadata so CI can verify stable semantic version format and consistency with `src/foundation/release-metadata.mjs`.
+
+Run `npm run build:debug-artifacts` before release packaging changes so CI can verify the public debug artifact matrix without accessing signing credentials.
 
 ## Epic Decomposition
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ npm run validate:secrets
 npm run audit:security
 npm run validate:foundation
 npm run validate:release
+npm run build:debug-artifacts
 npm run decompose:dry-run
 ```
 
@@ -56,6 +57,7 @@ npm run validate:secrets
 npm run audit:security
 npm run validate:foundation
 npm run validate:release
+npm run build:debug-artifacts
 npm run decompose:dry-run
 ```
 
@@ -87,6 +89,7 @@ Use these documents as the source of truth for foundation work:
 - `PRIVACY.md` for data handling principles and security reporting.
 - `docs/security-audit.md` for secret scanning, credential rotation, and secure storage review requirements.
 - `docs/license-matrix.md` for TDLib, Telegram reference client, Teleton Agent, and TON SDK license obligations before release readiness.
+- `docs/release-packaging.md` for APK, IPA, DMG, EXE, and AppImage artifact targets, public debug manifests, and protected signing boundaries.
 - `docs/architecture.md` for planned layers and integration boundaries.
 - `docs/tdlib-adapter.md` for TDLib adapter and credential handling rules.
 - `docs/release-strategy.md` for release metadata policy.

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This repository is in the foundation phase. The current implementation establish
 - Published security policy for supported versions, private vulnerability reporting, coordinated disclosure, and human maintainer review before release.
 - Upstream license matrix for TDLib, Telegram reference clients, Teleton Agent, and TON SDK release review.
 - Documented semantic version source of truth and release metadata validation.
+- Release artifact matrix for APK, IPA, DMG, EXE, and AppImage packaging, with unsigned debug artifact manifests built in public CI and signing reserved for protected environments.
 - Required project documents: `README.md`, `SECURITY.md`, `PRIVACY.md`, `LICENSE`, and `BUILD-GUIDE.md`.
 
 ## Quick Start
@@ -59,6 +60,7 @@ npm run validate:secrets
 npm run audit:security
 npm run validate:foundation
 npm run validate:release
+npm run build:debug-artifacts
 npm run decompose:dry-run
 ```
 
@@ -78,7 +80,7 @@ The project is intended to evolve through these layers:
 4. TON blockchain integrations for wallet, transfers, swaps, NFTs, staking, and DNS.
 5. Security and privacy controls for credentials, user consent, and auditability.
 
-See `SECURITY.md`, `docs/architecture.md`, `docs/backlog.md`, `docs/tdlib-adapter.md`, `docs/android-wrapper.md`, `docs/ios-wrapper.md`, `docs/desktop-wrapper.md`, `docs/tablet-layout.md`, `docs/web-pwa-wrapper.md`, `docs/security-audit.md`, `docs/license-matrix.md`, and `docs/release-strategy.md` for the current foundation plan. The agent settings, local runtime, input action map, Android wrapper, iOS wrapper, desktop wrapper, tablet layout, PWA, message database encryption, secure data deletion, security policy, security audit, and license matrix sections record the shared settings UI contract, supported runtime directions, platform execution boundaries, shortcut and gesture behavior, hardware security key capability checks, responsive tablet behavior, web installability behavior, vulnerability reporting expectations, credential rotation expectations, secure storage review requirements, upstream license obligations, and remaining packaging gaps for Android, iOS, desktop, and web wrappers.
+See `SECURITY.md`, `docs/architecture.md`, `docs/backlog.md`, `docs/tdlib-adapter.md`, `docs/android-wrapper.md`, `docs/ios-wrapper.md`, `docs/desktop-wrapper.md`, `docs/tablet-layout.md`, `docs/web-pwa-wrapper.md`, `docs/security-audit.md`, `docs/license-matrix.md`, `docs/release-strategy.md`, and `docs/release-packaging.md` for the current foundation plan. The agent settings, local runtime, input action map, Android wrapper, iOS wrapper, desktop wrapper, tablet layout, PWA, message database encryption, secure data deletion, security policy, security audit, license matrix, and release packaging sections record the shared settings UI contract, supported runtime directions, platform execution boundaries, shortcut and gesture behavior, hardware security key capability checks, responsive tablet behavior, web installability behavior, vulnerability reporting expectations, credential rotation expectations, secure storage review requirements, upstream license obligations, protected signing boundaries, and remaining native packaging implementation gaps for Android, iOS, desktop, and web wrappers.
 
 ## Contribution Templates
 

--- a/docs/release-packaging.md
+++ b/docs/release-packaging.md
@@ -1,0 +1,39 @@
+# Release Packaging
+
+Teleton Client release packaging is represented by the foundation artifact matrix in `src/foundation/release-artifacts.mjs`. The current repository does not contain native Gradle, Xcode, or Electron sources yet, so public CI builds unsigned debug artifact manifests that record the reviewed output contracts. Native package builders can replace the manifest-only commands once those platform sources land.
+
+Pull requests do not receive signing secrets. Public CI runs `npm run build:debug-artifacts` and uploads unsigned debug manifests only. Signed release packages must be created from reviewed commits inside the protected environment named `release-signing`.
+
+## Artifact Matrix
+
+| Target | Release artifact | Debug build id | Debug artifact built by public CI | Runner | Signing boundary |
+| --- | --- | --- | --- | --- | --- |
+| Android | APK at `android/app/build/outputs/apk/release/app-release.apk` | `android-debug-apk` | APK contract at `android/app/build/outputs/apk/debug/app-debug.apk` | `ubuntu-latest` | Android keystore references resolved only in `release-signing` |
+| iOS | IPA at `ios/build/ipa/TeletonClient.ipa` | `ios-debug-app-bundle` | Simulator app contract at `ios/build/Build/Products/Debug-iphonesimulator/TeletonClient.app` | `macos-latest` | Apple signing identities and export profiles resolved only in `release-signing` |
+| macOS | DMG at `desktop/dist/macos/Teleton Client-${version}-macos-${arch}.dmg` | `desktop-macos-debug-app-bundle` | App bundle contract at `desktop/out/debug/macos-x64/Teleton Client.app` | `macos-latest` | Developer ID signing and notarization resolved only in `release-signing` |
+| Windows | EXE installer at `desktop/dist/windows/Teleton Client Setup ${version}-${arch}.exe` | `desktop-windows-debug-exe` | Debug executable contract at `desktop/out/debug/windows-x64/Teleton Client.exe` | `windows-latest` | Authenticode certificate references resolved only in `release-signing` |
+| Linux | AppImage at `desktop/dist/linux/Teleton Client-${version}-${arch}.AppImage` | `desktop-linux-debug-executable` | Debug executable contract at `desktop/out/debug/linux-x64/teleton-client` | `ubuntu-latest` | Optional AppImage signature references resolved only in `release-signing` |
+
+## Public CI Debug Builds
+
+The release validation workflow runs a matrix job for Android, iOS, macOS, Windows, and Linux debug targets. Each matrix entry:
+
+- checks out the pull request code with read-only repository permissions;
+- runs `npm run build:debug-artifacts -- --target <debug-build-id>`;
+- uploads one JSON manifest through `actions/upload-artifact`;
+- records `usesSigningSecrets: false` and `signsArtifacts: false`.
+
+These manifests are review evidence, not signed installers. They keep the package paths, runner choices, and signing boundary visible before native build sources are introduced.
+
+## Protected Signing And Publication
+
+Release managers should prepare signed packages only after the pull request has merged and human release review has approved the version, changelog, license matrix, security audit, and platform wrapper contracts.
+
+1. Check out the reviewed commit from `main` or a protected release tag.
+2. Run the local validation commands from `BUILD-GUIDE.md`, including `npm run validate:release` and `npm run build:debug-artifacts`.
+3. Enter the protected `release-signing` environment and resolve only secure references needed for the target package.
+4. Produce the platform package: Gradle release APK, Xcode archive/export IPA, electron-builder DMG, electron-builder NSIS EXE, or electron-builder AppImage.
+5. Sign, notarize, timestamp, or attach optional AppImage signatures according to the target row in the artifact matrix.
+6. Attach the public CI debug manifest, security audit report, changelog preview, and signing evidence to the release review before publication.
+
+Signing credentials, private keys, Apple certificates, Android keystores, Authenticode certificates, notarization tokens, wallet material, Telegram credentials, and private message data must not be pasted into pull requests, logs, issue comments, screenshots, fixtures, or committed configuration.

--- a/docs/release-strategy.md
+++ b/docs/release-strategy.md
@@ -10,6 +10,12 @@ Teleton Client uses `package.json` as the single source of truth for package, ap
 
 The package remains private until a reviewed release workflow is introduced. Pull requests and issue branches can validate metadata, but they do not publish packages.
 
+## Package Artifact Matrix
+
+`src/foundation/release-artifacts.mjs` defines the reviewed package matrix for Android APK, iOS IPA, macOS DMG, Windows EXE, and Linux AppImage targets. Public pull request CI builds unsigned debug artifact manifests for every supported platform runner and uploads those manifests as review evidence.
+
+See `docs/release-packaging.md` for the artifact paths, runner matrix, protected signing boundary, and publication checklist. Pull requests do not receive signing secrets; signed packages must be produced only from reviewed commits inside the protected `release-signing` environment.
+
 ## Semantic Versioning
 
 Versions must use stable semantic version format: `MAJOR.MINOR.PATCH`.
@@ -24,6 +30,7 @@ The helper `classifyVersionBump(previousVersion, nextVersion)` records these rul
 ## Automation Rules
 
 - CI runs `npm run validate:release` for pull requests and pushes to `main` or `issue-*` branches.
+- CI runs `npm run build:debug-artifacts` for Android, iOS, macOS, Windows, and Linux debug artifact manifests, then uploads the unsigned manifests for review.
 - CI previews generated changelog notes with `npm run changelog` so reviewers can inspect the release-note format before publication.
 - Release validation checks metadata consistency and stable semantic version syntax.
 - Publishing is intentionally absent from pull request workflows, so unreviewed pull request code cannot publish packages.

--- a/docs/security-audit.md
+++ b/docs/security-audit.md
@@ -29,7 +29,7 @@ The generated Markdown report records the release gate status, automated securit
 | Secrets | `npm run validate:secrets` scans git-tracked text files and fails on common secret patterns. | Security reviewer confirms credential rotation, secure storage, logs, screenshots, fixtures, pull request text, and release notes are redacted. |
 | Dependency risk | `package.json` dependency metadata and lockfile coverage are checked, and `docs/license-matrix.md` must track upstream license and source publication obligations. | Legal or release reviewer confirms selected dependencies match the license matrix and approves TDLib, Telegram reference, Teleton Agent, TON SDK, copyleft, notice, and app-store obligations. |
 | Permission boundaries | CODEOWNERS coverage, workflow `contents: read` permissions, secure storage review language, and non-publishing release validation are checked. | Security reviewer confirms platform bridges resolve secrets locally, redact diagnostics, and keep elevated permissions out of unreviewed pull request workflows. |
-| Release readiness | `npm run validate:release`, package private state, the audit command, and release workflow artifact generation are checked. | Release manager attaches the report, records validation results, confirms changelog redaction, and keeps publication disabled until public release approval. |
+| Release readiness | `npm run validate:release`, `npm run build:debug-artifacts`, package private state, the audit command, and release workflow artifact generation are checked. | Release manager attaches the report, records validation results, confirms changelog redaction, and keeps publication disabled until public release approval. |
 
 Manual review items must be completed before public release even when automated checks pass.
 
@@ -97,7 +97,7 @@ The secure deletion workflow must describe filesystem limitations before release
 
 Security and privacy changes require CODEOWNERS review by a human maintainer. Before release, request a human security review that covers:
 
-- The latest `npm run validate:secrets`, `npm test`, `npm run validate:foundation`, and `npm run validate:release` results.
+- The latest `npm run validate:secrets`, `npm test`, `npm run validate:foundation`, `npm run validate:release`, and `npm run build:debug-artifacts` results.
 - Any changes to secret patterns or allowlisted fixtures.
 - Platform secure storage bindings and diagnostic redaction behavior.
 - Hardware security key platform capability detection, relying-party id and origin binding, registration and assertion verification boundaries, explicit fallback behavior, and release enablement flags.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "validate:secrets": "node scripts/validate-secrets.mjs",
     "validate:foundation": "node scripts/validate-foundation.mjs",
     "validate:release": "node scripts/validate-release.mjs",
+    "build:debug-artifacts": "node scripts/build-debug-artifacts.mjs",
     "changelog": "node scripts/generate-changelog.mjs",
     "changelog:write": "node scripts/generate-changelog.mjs --write",
     "changelog:check": "node scripts/generate-changelog.mjs --check",

--- a/scripts/build-debug-artifacts.mjs
+++ b/scripts/build-debug-artifacts.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import {
+  assertReleaseArtifactMatrix,
+  createDebugArtifactBuildManifest,
+  createDebugArtifactBuildManifests,
+  listDebugArtifactBuilds
+} from '../src/foundation/release-artifacts.mjs';
+
+function usage() {
+  return [
+    'Usage: node scripts/build-debug-artifacts.mjs [options]',
+    '',
+    'Options:',
+    '  --target <id|all>        Debug artifact build id to write. Defaults to all.',
+    '  --output <directory>     Output directory. Defaults to dist/debug-artifacts.',
+    '  --build-id <id>          Build identifier. Defaults to GITHUB_SHA or local-debug.',
+    '  --generated-at <iso>     Manifest timestamp. Defaults to the current time.',
+    '  --help                   Show this help.'
+  ].join('\n');
+}
+
+function parseArgs(argv) {
+  const options = {
+    target: 'all',
+    output: 'dist/debug-artifacts',
+    buildId: process.env.GITHUB_SHA ?? 'local-debug',
+    generatedAt: undefined
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--help') {
+      return { ...options, help: true };
+    }
+
+    if (['--target', '--output', '--build-id', '--generated-at'].includes(arg)) {
+      const value = argv[index + 1];
+      if (!value) {
+        throw new Error(`${arg} requires a value.`);
+      }
+
+      if (arg === '--target') {
+        options.target = value;
+      } else if (arg === '--output') {
+        options.output = value;
+      } else if (arg === '--build-id') {
+        options.buildId = value;
+      } else {
+        options.generatedAt = value;
+      }
+
+      index += 1;
+      continue;
+    }
+
+    throw new Error(`Unknown argument: ${arg}`);
+  }
+
+  return options;
+}
+
+function manifestsForTarget(target, options) {
+  if (target === 'all') {
+    return createDebugArtifactBuildManifests(options);
+  }
+
+  const debugBuildIds = new Set(listDebugArtifactBuilds().map((build) => build.id));
+  if (!debugBuildIds.has(target)) {
+    throw new Error(`Unsupported debug artifact target: ${target}. Supported targets: ${[...debugBuildIds].join(', ')}`);
+  }
+
+  return [createDebugArtifactBuildManifest(target, options)];
+}
+
+const options = parseArgs(process.argv.slice(2));
+
+if (options.help) {
+  console.log(usage());
+  process.exit(0);
+}
+
+assertReleaseArtifactMatrix();
+
+const outputDir = resolve(options.output);
+const manifests = manifestsForTarget(options.target, {
+  buildId: options.buildId,
+  generatedAt: options.generatedAt
+});
+
+await mkdir(outputDir, { recursive: true });
+
+for (const manifest of manifests) {
+  await writeFile(`${outputDir}/${manifest.id}.json`, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+}
+
+console.log(`Wrote ${manifests.length} debug artifact manifest(s) to ${outputDir}.`);

--- a/scripts/validate-foundation.mjs
+++ b/scripts/validate-foundation.mjs
@@ -24,6 +24,7 @@ const requiredFiles = [
   'docs/contributing-templates.md',
   'docs/architecture.md',
   'docs/release-strategy.md',
+  'docs/release-packaging.md',
   'docs/security-audit.md',
   'docs/license-matrix.md',
   'docs/backlog.md',
@@ -39,7 +40,10 @@ const requiredFiles = [
   'src/foundation/agent-action-history.mjs',
   'test/agent-action-history.test.mjs',
   'src/foundation/agent-plugin-registry.mjs',
-  'test/agent-plugin-registry.test.mjs'
+  'test/agent-plugin-registry.test.mjs',
+  'src/foundation/release-artifacts.mjs',
+  'scripts/build-debug-artifacts.mjs',
+  'test/release-artifacts.test.mjs'
 ];
 
 for (const requiredFile of requiredFiles) {
@@ -134,12 +138,14 @@ const requiredContributingPatterns = [
   /npm run audit:security/,
   /npm run validate:foundation/,
   /npm run validate:release/,
+  /npm run build:debug-artifacts/,
   /npm run decompose:dry-run/,
   /docs\/contributing-templates\.md/,
   /BUILD-GUIDE\.md/,
   /SECURITY\.md/,
   /PRIVACY\.md/,
   /docs\/license-matrix\.md/,
+  /docs\/release-packaging\.md/,
   /secrets/i,
   /credentials/i,
   /Telegram API IDs or hashes/i,
@@ -163,9 +169,16 @@ assert.equal(
   'package.json must expose the secret validation command'
 );
 
+assert.equal(
+  packageJson.scripts['build:debug-artifacts'],
+  'node scripts/build-debug-artifacts.mjs',
+  'package.json must expose the debug artifact manifest build command'
+);
+
 const preCommitHook = await readFile(new URL('.githooks/pre-commit', root), 'utf8');
 assert.match(preCommitHook, /npm run validate:secrets/, 'pre-commit hook must run the secret scan');
 assert.match(preCommitHook, /npm run audit:security/, 'pre-commit hook must generate security audit evidence');
+assert.match(preCommitHook, /npm run build:debug-artifacts/, 'pre-commit hook must build debug artifact manifests');
 
 const ciWorkflow = await readFile(new URL('.github/workflows/ci.yml', root), 'utf8');
 assert.match(ciWorkflow, /npm run validate:secrets/, 'CI must run the secret scan');
@@ -186,6 +199,16 @@ assert.match(
   releaseWorkflow,
   /if:\s*always\(\)/,
   'release validation must preserve the security audit artifact when audit checks fail'
+);
+assert.match(
+  releaseWorkflow,
+  /npm run build:debug-artifacts/,
+  'release validation must build public debug artifact manifests'
+);
+assert.doesNotMatch(
+  releaseWorkflow,
+  /\bsecrets\./,
+  'pull request release validation must not reference signing secrets'
 );
 
 const securityAudit = await readFile(new URL('docs/security-audit.md', root), 'utf8');

--- a/scripts/validate-release.mjs
+++ b/scripts/validate-release.mjs
@@ -3,10 +3,13 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
 import { RELEASE_METADATA, VERSION_SOURCE_OF_TRUTH, isStableSemver } from '../src/foundation/release-metadata.mjs';
+import { assertReleaseArtifactMatrix, listReleaseArtifactTargets } from '../src/foundation/release-artifacts.mjs';
 
 const root = new URL('../', import.meta.url);
 const packageJson = JSON.parse(await readFile(new URL('package.json', root), 'utf8'));
 const changelog = await readFile(new URL('CHANGELOG.md', root), 'utf8');
+const releaseWorkflow = await readFile(new URL('.github/workflows/release-validation.yml', root), 'utf8');
+const releasePackaging = await readFile(new URL('docs/release-packaging.md', root), 'utf8');
 
 assert.equal(VERSION_SOURCE_OF_TRUTH, 'package.json', 'package.json must be the documented version source of truth');
 assert.equal(RELEASE_METADATA.sourceOfTruth, VERSION_SOURCE_OF_TRUTH, 'release metadata must name its source of truth');
@@ -17,5 +20,22 @@ assert.equal(isStableSemver(packageJson.version), true, 'package.json version mu
 assert.equal(packageJson.private, true, 'foundation package must remain private until reviewed release automation is added');
 assert.match(changelog, /^# Changelog/m, 'CHANGELOG.md must be present for reviewed release notes');
 assert.match(changelog, /reviewed before publication/i, 'CHANGELOG.md must document manual review before publishing');
+assert.equal(
+  packageJson.scripts['build:debug-artifacts'],
+  'node scripts/build-debug-artifacts.mjs',
+  'package.json must expose the public debug artifact manifest build command'
+);
+assertReleaseArtifactMatrix();
+assert.match(releaseWorkflow, /debug-artifacts:/, 'release workflow must build debug artifact manifests');
+assert.match(releaseWorkflow, /npm run build:debug-artifacts/, 'release workflow must run the debug artifact builder');
+assert.match(releaseWorkflow, /actions\/upload-artifact@v4/, 'release workflow must upload debug artifact manifests');
+assert.doesNotMatch(releaseWorkflow, /\bsecrets\./, 'pull request release workflow must not reference signing secrets');
+assert.match(releasePackaging, /pull requests? do not receive signing secrets/i);
+assert.match(releasePackaging, /protected environment/i);
+
+for (const target of listReleaseArtifactTargets()) {
+  assert.match(releasePackaging, new RegExp(target.release.format, 'i'), `${target.release.format} must be documented`);
+  assert.match(releasePackaging, new RegExp(target.debugBuild.id, 'i'), `${target.debugBuild.id} must be documented`);
+}
 
 console.log(`Release validation passed for ${packageJson.name}@${packageJson.version}.`);

--- a/src/foundation/release-artifacts.mjs
+++ b/src/foundation/release-artifacts.mjs
@@ -1,0 +1,335 @@
+import { createAndroidDebugBuildArtifact } from '../platform/android-wrapper.mjs';
+import { createDesktopDebugBuildArtifact, describeDesktopPackagingPlan } from '../platform/desktop-wrapper.mjs';
+import { createIosDebugBuildArtifact } from '../platform/ios-wrapper.mjs';
+
+export const RELEASE_SIGNING_ENVIRONMENT = 'release-signing';
+
+const REQUIRED_TARGET_IDS = Object.freeze(['android-apk', 'ios-ipa', 'macos-dmg', 'windows-exe', 'linux-appimage']);
+const REQUIRED_RELEASE_FORMATS = Object.freeze(['apk', 'ipa', 'dmg', 'exe', 'AppImage']);
+const REQUIRED_DEBUG_BUILD_IDS = Object.freeze([
+  'android-debug-apk',
+  'ios-debug-app-bundle',
+  'desktop-macos-debug-app-bundle',
+  'desktop-windows-debug-exe',
+  'desktop-linux-debug-executable'
+]);
+
+const desktopPackaging = describeDesktopPackagingPlan();
+
+function deepFreeze(value) {
+  if (!value || typeof value !== 'object') {
+    return value;
+  }
+
+  for (const child of Object.values(value)) {
+    deepFreeze(child);
+  }
+
+  return Object.freeze(value);
+}
+
+function clone(value) {
+  return structuredClone(value);
+}
+
+function signingPlan({ requiredInputs, reviewerChecklist }) {
+  return {
+    required: true,
+    environment: RELEASE_SIGNING_ENVIRONMENT,
+    availableInPullRequests: false,
+    requiredInputs,
+    reviewerChecklist
+  };
+}
+
+function publicCiPlan({ runner, command }) {
+  return {
+    enabled: true,
+    runner,
+    command,
+    signsArtifacts: false,
+    usesSigningSecrets: false,
+    uploadsManifest: true
+  };
+}
+
+export const RELEASE_ARTIFACT_MATRIX = deepFreeze([
+  {
+    id: 'android-apk',
+    platform: 'android',
+    os: 'android',
+    displayName: 'Android APK',
+    release: {
+      format: 'apk',
+      path: 'android/app/build/outputs/apk/release/app-release.apk',
+      builder: 'Gradle Android Plugin assembleRelease',
+      artifactName: 'TeletonClient-${version}-android-${arch}.apk'
+    },
+    debugBuild: {
+      id: 'android-debug-apk',
+      artifact: createAndroidDebugBuildArtifact(),
+      publicCi: publicCiPlan({
+        runner: 'ubuntu-latest',
+        command: 'npm run build:debug-artifacts -- --target android-debug-apk'
+      })
+    },
+    signing: signingPlan({
+      requiredInputs: ['android-keystore-ref', 'android-key-alias-ref', 'android-key-password-ref'],
+      reviewerChecklist: [
+        'Resolve keystore material only inside the protected release-signing environment.',
+        'Confirm app id dev.teleton.client and package name dev.teleton.client match reviewed metadata.',
+        'Attach the unsigned debug APK manifest from public CI to the release review.'
+      ]
+    })
+  },
+  {
+    id: 'ios-ipa',
+    platform: 'ios',
+    os: 'ios',
+    displayName: 'iOS IPA',
+    release: {
+      format: 'ipa',
+      path: 'ios/build/ipa/TeletonClient.ipa',
+      builder: 'xcodebuild archive and exportArchive',
+      artifactName: 'TeletonClient-${version}-ios-${arch}.ipa'
+    },
+    debugBuild: {
+      id: 'ios-debug-app-bundle',
+      artifact: createIosDebugBuildArtifact(),
+      publicCi: publicCiPlan({
+        runner: 'macos-latest',
+        command: 'npm run build:debug-artifacts -- --target ios-debug-app-bundle'
+      })
+    },
+    signing: signingPlan({
+      requiredInputs: ['apple-team-id-ref', 'apple-signing-certificate-ref', 'app-store-connect-profile-ref'],
+      reviewerChecklist: [
+        'Resolve Apple signing identities only inside the protected release-signing environment.',
+        'Confirm entitlements, APNs topics, and App Store review notes match the reviewed iOS wrapper contract.',
+        'Attach the unsigned simulator app manifest from public CI to the release review.'
+      ]
+    })
+  },
+  {
+    id: 'macos-dmg',
+    platform: 'desktop',
+    os: 'macos',
+    displayName: 'macOS DMG',
+    release: {
+      format: desktopPackaging.macos.format,
+      path: 'desktop/dist/macos/Teleton Client-${version}-macos-${arch}.dmg',
+      builder: `electron-builder ${desktopPackaging.macos.builderTarget}`,
+      artifactName: desktopPackaging.macos.artifactName
+    },
+    debugBuild: {
+      id: 'desktop-macos-debug-app-bundle',
+      artifact: createDesktopDebugBuildArtifact({ os: 'macos' }),
+      publicCi: publicCiPlan({
+        runner: 'macos-latest',
+        command: 'npm run build:debug-artifacts -- --target desktop-macos-debug-app-bundle'
+      })
+    },
+    signing: signingPlan({
+      requiredInputs: ['developer-id-application-ref', 'notarization-apple-id-ref', 'notarization-team-id-ref'],
+      reviewerChecklist: [
+        'Sign the app bundle with Developer ID inside the protected release-signing environment.',
+        'Notarize the DMG before distribution and attach notarization evidence to the release review.',
+        'Attach the unsigned macOS debug app manifest from public CI to the release review.'
+      ]
+    })
+  },
+  {
+    id: 'windows-exe',
+    platform: 'desktop',
+    os: 'windows',
+    displayName: 'Windows EXE installer',
+    release: {
+      format: desktopPackaging.windows.format,
+      path: 'desktop/dist/windows/Teleton Client Setup ${version}-${arch}.exe',
+      builder: `electron-builder ${desktopPackaging.windows.builderTarget}`,
+      artifactName: desktopPackaging.windows.artifactName
+    },
+    debugBuild: {
+      id: 'desktop-windows-debug-exe',
+      artifact: createDesktopDebugBuildArtifact({ os: 'windows' }),
+      publicCi: publicCiPlan({
+        runner: 'windows-latest',
+        command: 'npm run build:debug-artifacts -- --target desktop-windows-debug-exe'
+      })
+    },
+    signing: signingPlan({
+      requiredInputs: ['authenticode-certificate-ref', 'timestamp-service-url-ref'],
+      reviewerChecklist: [
+        'Resolve Authenticode certificate material only inside the protected release-signing environment.',
+        'Timestamp the NSIS installer before update or installer distribution.',
+        'Attach the unsigned Windows debug executable manifest from public CI to the release review.'
+      ]
+    })
+  },
+  {
+    id: 'linux-appimage',
+    platform: 'desktop',
+    os: 'linux',
+    displayName: 'Linux AppImage',
+    release: {
+      format: desktopPackaging.linux.format,
+      path: 'desktop/dist/linux/Teleton Client-${version}-${arch}.AppImage',
+      builder: `electron-builder ${desktopPackaging.linux.builderTarget}`,
+      artifactName: desktopPackaging.linux.artifactName
+    },
+    debugBuild: {
+      id: 'desktop-linux-debug-executable',
+      artifact: createDesktopDebugBuildArtifact({ os: 'linux' }),
+      publicCi: publicCiPlan({
+        runner: 'ubuntu-latest',
+        command: 'npm run build:debug-artifacts -- --target desktop-linux-debug-executable'
+      })
+    },
+    signing: signingPlan({
+      requiredInputs: ['appimage-signature-ref'],
+      reviewerChecklist: [
+        'Build AppImage release output in the protected release-signing environment before publication.',
+        'Apply optional AppImage signature only after license and security review complete.',
+        'Attach the unsigned Linux debug executable manifest from public CI to the release review.'
+      ]
+    })
+  }
+]);
+
+function targetByDebugBuildId(debugBuildId, matrix = RELEASE_ARTIFACT_MATRIX) {
+  return matrix.find((target) => target.debugBuild.id === debugBuildId);
+}
+
+export function listReleaseArtifactTargets() {
+  return clone(RELEASE_ARTIFACT_MATRIX);
+}
+
+export function listDebugArtifactBuilds() {
+  return RELEASE_ARTIFACT_MATRIX.map((target) => ({
+    ...clone(target.debugBuild),
+    releaseTargetId: target.id,
+    releaseFormat: target.release.format
+  }));
+}
+
+export function getReleaseArtifactTarget(targetId) {
+  const target = RELEASE_ARTIFACT_MATRIX.find((entry) => entry.id === targetId);
+
+  if (!target) {
+    throw new Error(`Unsupported release artifact target: ${targetId}`);
+  }
+
+  return clone(target);
+}
+
+export function getDebugArtifactBuild(debugBuildId) {
+  const target = targetByDebugBuildId(debugBuildId);
+
+  if (!target) {
+    throw new Error(`Unsupported debug artifact build: ${debugBuildId}`);
+  }
+
+  return {
+    ...clone(target.debugBuild),
+    releaseTargetId: target.id,
+    releaseFormat: target.release.format
+  };
+}
+
+export function validateReleaseArtifactMatrix(matrix = RELEASE_ARTIFACT_MATRIX) {
+  const errors = [];
+
+  if (!Array.isArray(matrix)) {
+    return ['Release artifact matrix must be an array.'];
+  }
+
+  const targetIds = matrix.map((target) => target.id);
+  const releaseFormats = matrix.map((target) => target.release?.format);
+  const debugBuildIds = matrix.map((target) => target.debugBuild?.id);
+
+  if (JSON.stringify(targetIds) !== JSON.stringify(REQUIRED_TARGET_IDS)) {
+    errors.push(`Release artifact targets must be ${REQUIRED_TARGET_IDS.join(', ')}.`);
+  }
+
+  if (JSON.stringify(releaseFormats) !== JSON.stringify(REQUIRED_RELEASE_FORMATS)) {
+    errors.push(`Release formats must be ${REQUIRED_RELEASE_FORMATS.join(', ')}.`);
+  }
+
+  if (JSON.stringify(debugBuildIds) !== JSON.stringify(REQUIRED_DEBUG_BUILD_IDS)) {
+    errors.push(`Debug build ids must be ${REQUIRED_DEBUG_BUILD_IDS.join(', ')}.`);
+  }
+
+  for (const target of matrix) {
+    const label = target?.id ?? '<unknown>';
+
+    if (!target?.release?.path) {
+      errors.push(`${label} must declare a release artifact path.`);
+    }
+
+    if (!target?.debugBuild?.artifact?.path) {
+      errors.push(`${label} must declare a debug artifact path.`);
+    }
+
+    if (target?.debugBuild?.publicCi?.enabled !== true) {
+      errors.push(`${label} must enable public CI debug artifact builds.`);
+    }
+
+    if (target?.debugBuild?.publicCi?.signsArtifacts !== false) {
+      errors.push(`${label} public CI builds must stay unsigned.`);
+    }
+
+    if (target?.debugBuild?.publicCi?.usesSigningSecrets !== false) {
+      errors.push(`${label} public CI builds must not use signing secrets.`);
+    }
+
+    if (target?.signing?.environment !== RELEASE_SIGNING_ENVIRONMENT) {
+      errors.push(`${label} signing must use the ${RELEASE_SIGNING_ENVIRONMENT} environment.`);
+    }
+
+    if (target?.signing?.availableInPullRequests !== false) {
+      errors.push(`${label} signing material must not be available to pull requests.`);
+    }
+  }
+
+  return errors;
+}
+
+export function assertReleaseArtifactMatrix(matrix = RELEASE_ARTIFACT_MATRIX) {
+  const errors = validateReleaseArtifactMatrix(matrix);
+
+  if (errors.length > 0) {
+    throw new Error(`Invalid release artifact matrix:\n- ${errors.join('\n- ')}`);
+  }
+
+  return true;
+}
+
+export function createDebugArtifactBuildManifest(debugBuildId, options = {}) {
+  const target = targetByDebugBuildId(debugBuildId);
+
+  if (!target) {
+    throw new Error(`Unsupported debug artifact build: ${debugBuildId}`);
+  }
+
+  return {
+    schemaVersion: 1,
+    id: target.debugBuild.id,
+    releaseTargetId: target.id,
+    buildId: String(options.buildId ?? 'local-debug'),
+    generatedAt: String(options.generatedAt ?? new Date().toISOString()),
+    artifact: clone(target.debugBuild.artifact),
+    publicCi: clone(target.debugBuild.publicCi),
+    releaseTarget: {
+      id: target.id,
+      displayName: target.displayName,
+      platform: target.platform,
+      os: target.os,
+      release: clone(target.release),
+      signing: clone(target.signing)
+    }
+  };
+}
+
+export function createDebugArtifactBuildManifests(options = {}) {
+  return REQUIRED_DEBUG_BUILD_IDS.map((debugBuildId) => createDebugArtifactBuildManifest(debugBuildId, options));
+}

--- a/src/foundation/security-audit.mjs
+++ b/src/foundation/security-audit.mjs
@@ -27,7 +27,7 @@ export const SECURITY_AUDIT_MANUAL_REVIEW_ITEMS = Object.freeze([
     title: 'Human security reviewer',
     owner: 'security maintainer',
     evidence:
-      'Record the latest npm test, npm run validate:secrets, npm run audit:security, npm run validate:foundation, and npm run validate:release results.'
+      'Record the latest npm test, npm run validate:secrets, npm run audit:security, npm run validate:foundation, npm run validate:release, and npm run build:debug-artifacts results.'
   },
   {
     id: 'human-legal-reviewer',
@@ -291,14 +291,21 @@ export async function createSecurityAudit({
       title: 'Release Readiness',
       requiredEvidence: [
         'Release metadata and changelog checks pass before a release review.',
+        'Unsigned debug artifact manifests are built and uploaded by public CI without signing secrets.',
         'Security audit output is generated as Markdown and uploaded or attached to the release review.'
       ],
       checks: [
         createCheck({
           id: 'release-package-state',
           title: 'Package release state',
-          status: packageJson.private === true && packageJson.scripts?.['validate:release'] ? 'pass' : 'blocked',
-          evidence: 'package.json remains private and exposes npm run validate:release for metadata validation.',
+          status:
+            packageJson.private === true &&
+            packageJson.scripts?.['validate:release'] &&
+            packageJson.scripts?.['build:debug-artifacts']
+              ? 'pass'
+              : 'blocked',
+          evidence:
+            'package.json remains private and exposes npm run validate:release plus npm run build:debug-artifacts for release validation.',
           command: 'npm run validate:release'
         }),
         createCheck({
@@ -313,14 +320,16 @@ export async function createSecurityAudit({
           title: 'Release validation workflow',
           status:
             /npm run validate:release/.test(releaseWorkflow) &&
+            /npm run build:debug-artifacts/.test(releaseWorkflow) &&
             /npm run audit:security -- --output security-audit-report\.md/.test(releaseWorkflow) &&
             /actions\/upload-artifact@v4/.test(releaseWorkflow) &&
             /if:\s*always\(\)/.test(releaseWorkflow) &&
+            !/\bsecrets\./.test(releaseWorkflow) &&
             !/npm\s+publish/.test(releaseWorkflow)
               ? 'pass'
               : 'blocked',
           evidence:
-            '.github/workflows/release-validation.yml validates metadata, preserves the security audit report artifact, and does not publish.'
+            '.github/workflows/release-validation.yml validates metadata, uploads unsigned debug artifact manifests, preserves the security audit report artifact, and does not publish.'
         })
       ]
     })

--- a/test/foundation.test.mjs
+++ b/test/foundation.test.mjs
@@ -31,6 +31,7 @@ test('foundation artifacts required by issue 1 are present', () => {
     '.github/pull_request_template.md',
     'config/epic-subtasks.json',
     'docs/release-strategy.md',
+    'docs/release-packaging.md',
     'docs/security-audit.md',
     'docs/license-matrix.md',
     'docs/contributing-templates.md',
@@ -111,6 +112,7 @@ test('pre-commit hook is installable and runs deterministic local checks', async
   assert.match(hook, /npm run audit:security/, 'pre-commit hook should generate security audit evidence');
   assert.match(hook, /npm run validate:foundation/, 'pre-commit hook should run foundation validation');
   assert.match(hook, /npm run validate:release/, 'pre-commit hook should run release metadata validation');
+  assert.match(hook, /npm run build:debug-artifacts/, 'pre-commit hook should build debug artifact manifests');
   assert.match(hook, /npm run decompose:dry-run/, 'pre-commit hook should run the deterministic dry run');
 });
 

--- a/test/release-artifacts.test.mjs
+++ b/test/release-artifacts.test.mjs
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+const root = new URL('../', import.meta.url);
+
+test('release artifact matrix covers mobile and desktop package formats with unsigned debug CI builds', async () => {
+  const release = await import('../src/foundation/release-artifacts.mjs');
+  const targets = release.listReleaseArtifactTargets();
+  const debugBuilds = release.listDebugArtifactBuilds();
+
+  assert.deepEqual(
+    targets.map((target) => target.id),
+    ['android-apk', 'ios-ipa', 'macos-dmg', 'windows-exe', 'linux-appimage']
+  );
+  assert.deepEqual(
+    targets.map((target) => target.release.format),
+    ['apk', 'ipa', 'dmg', 'exe', 'AppImage']
+  );
+  assert.deepEqual(
+    debugBuilds.map((build) => build.id),
+    [
+      'android-debug-apk',
+      'ios-debug-app-bundle',
+      'desktop-macos-debug-app-bundle',
+      'desktop-windows-debug-exe',
+      'desktop-linux-debug-executable'
+    ]
+  );
+
+  for (const target of targets) {
+    assert.equal(target.signing.availableInPullRequests, false, `${target.id} signing must stay out of PRs`);
+    assert.equal(target.signing.environment, 'release-signing', `${target.id} must use the protected signing environment`);
+  }
+
+  for (const build of debugBuilds) {
+    assert.equal(build.publicCi.enabled, true, `${build.id} should be built by public CI`);
+    assert.equal(build.publicCi.signsArtifacts, false, `${build.id} must be unsigned in public CI`);
+    assert.equal(build.publicCi.usesSigningSecrets, false, `${build.id} must not use signing secrets`);
+    assert.ok(build.artifact.path, `${build.id} must describe the debug artifact path`);
+  }
+
+  assert.doesNotThrow(() => release.assertReleaseArtifactMatrix());
+});
+
+test('debug artifact build script writes CI manifest artifacts without signing material', async (t) => {
+  const outputDir = await mkdtemp(join(tmpdir(), 'teleton-debug-artifacts-'));
+  t.after(() => rm(outputDir, { recursive: true, force: true }));
+
+  const result = spawnSync(
+    process.execPath,
+    [
+      'scripts/build-debug-artifacts.mjs',
+      '--target',
+      'android-debug-apk',
+      '--build-id',
+      'ci-123',
+      '--generated-at',
+      '2026-04-27T00:00:00.000Z',
+      '--output',
+      outputDir
+    ],
+    {
+      cwd: new URL('.', root),
+      encoding: 'utf8'
+    }
+  );
+
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+
+  const manifest = JSON.parse(await readFile(join(outputDir, 'android-debug-apk.json'), 'utf8'));
+  assert.equal(manifest.id, 'android-debug-apk');
+  assert.equal(manifest.buildId, 'ci-123');
+  assert.equal(manifest.generatedAt, '2026-04-27T00:00:00.000Z');
+  assert.equal(manifest.artifact.path, 'android/app/build/outputs/apk/debug/app-debug.apk');
+  assert.equal(manifest.publicCi.usesSigningSecrets, false);
+  assert.equal(manifest.releaseTarget.release.format, 'apk');
+});
+
+test('release workflows and docs keep signing separate from pull request debug artifacts', async () => {
+  const workflow = await readFile(new URL('.github/workflows/release-validation.yml', root), 'utf8');
+  const packageJson = JSON.parse(await readFile(new URL('package.json', root), 'utf8'));
+  const releasePackaging = await readFile(new URL('docs/release-packaging.md', root), 'utf8');
+  const releaseStrategy = await readFile(new URL('docs/release-strategy.md', root), 'utf8');
+
+  assert.equal(packageJson.scripts['build:debug-artifacts'], 'node scripts/build-debug-artifacts.mjs');
+  assert.match(workflow, /debug-artifacts:/, 'release validation must include a debug artifact job');
+  assert.match(workflow, /npm run build:debug-artifacts/, 'CI must build debug artifact manifests');
+  assert.match(workflow, /actions\/upload-artifact@v4/, 'CI must upload debug artifact evidence');
+  assert.doesNotMatch(workflow, /\bsecrets\./, 'pull request workflow must not reference GitHub secrets');
+
+  for (const runner of ['ubuntu-latest', 'macos-latest', 'windows-latest']) {
+    assert.match(workflow, new RegExp(runner), `CI must cover ${runner} for supported debug targets`);
+  }
+
+  for (const format of ['APK', 'IPA', 'DMG', 'EXE', 'AppImage']) {
+    assert.match(releasePackaging, new RegExp(format), `release packaging docs must list ${format}`);
+  }
+
+  assert.match(releasePackaging, /protected environment/i, 'docs must route signing through protected environments');
+  assert.match(releasePackaging, /pull requests? do not receive signing secrets/i);
+  assert.match(releaseStrategy, /docs\/release-packaging\.md/);
+});


### PR DESCRIPTION
## Summary

- Adds a dependency-free release artifact matrix for Android APK, iOS IPA, macOS DMG, Windows EXE, and Linux AppImage targets.
- Adds `npm run build:debug-artifacts` to emit unsigned debug artifact manifests, and wires release validation CI to upload those manifests across Ubuntu, macOS, and Windows runners without signing secrets.
- Documents protected `release-signing` publication steps in `docs/release-packaging.md` and extends release/security validation around the packaging boundary.
- Removes the generated placeholder `.gitkeep` from the issue branch.

## Issue

Fixes #28

## Reproduction / Verification

Before this work, `node --test test/release-artifacts.test.mjs` failed because there was no release artifact matrix module, debug artifact manifest builder, or release packaging guide. The new regression test verifies the APK/IPA/DMG/EXE/AppImage matrix, unsigned public CI debug artifacts, protected signing boundary, workflow upload behavior, and documentation coverage.

## Tests

- [x] `npm test`
- [x] `npm run validate:secrets`
- [x] `npm run audit:security`
- [x] `npm run validate:foundation`
- [x] `npm run validate:release`
- [x] `npm run build:debug-artifacts`
- [x] `npm run decompose:dry-run`
- [x] `git diff --check --cached`

## Risk

This is foundation-level release automation: public CI uploads reviewed debug artifact manifests, not native signed binaries. Native Gradle, Xcode, and Electron package builders plus signing/notarization remain protected-environment work gated by human release review.

## Screenshots or recordings

Not applicable. This is release automation and documentation with no rendered UI.

## Security and privacy

- [x] This PR does not include secrets, production credentials, access tokens, Telegram API hashes, private keys, or private message content.
- [x] Any logs, screenshots, or fixtures are redacted.
- [x] Security-sensitive release automation changes request human maintainer review before release.
